### PR TITLE
Extend platform with project management APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.DS_Store
+npm-debug.log*
+.env

--- a/README.md
+++ b/README.md
@@ -154,8 +154,39 @@ Varsayılan olarak `http://localhost:4000` adresinde çalışan sunucu aşağıd
 - `POST /api/releases/:id/platforms` — Platforma build bağlar veya mağaza durumunu günceller.
 - `POST /api/releases/:id/promote` — Sürüm durumunu (draft, in_progress, published vb.) değiştirir.
 - `POST /api/releases/:id/timeline` — Serbest metin kilometre taşı mesajlarını sürüm geçmişine ekler.
+- `POST /api/pipeline/plan` — GitHub, Hostinger ve n8n entegrasyonlarını doğrulayarak çok platformlu bir dağıtım planı oluşturur.
+- `POST /api/pipeline/execute` — Oluşturulan planı çalıştırır, derlemeleri kuyruğa alır, sürümü terfi ettirir ve isteğe bağlı dağıtımı tetikler.
+- `GET /api/pipeline/runs` — Kaydedilen pipeline yürütmelerinin özetini güncel zamana göre sıralı döndürür.
+- `GET /api/pipeline/runs/detail?id=` — Belirli bir pipeline kaydının entegrasyon, sürüm ve dağıtım adımlarını gösterir.
 
 Tüm uç noktalar JSON isteği kabul eder ve örnek akışları simüle etmek üzere bellek içi durum deposu kullanır.
+
+#### Pipeline orkestrasyonu
+
+Pipeline uç noktaları, tek bir çağrıyla projenin derleme, sürüm ve dağıtım adımlarını uçtan uca simüle etmeye yardımcı olur:
+
+```bash
+curl -X POST http://localhost:4000/api/pipeline/execute \
+  -H 'Content-Type: application/json' \
+  -d '{
+        "projectId": "mobile-suite",
+        "version": "2.1.0",
+        "platforms": ["android", "ios", "web"],
+        "autoDeploy": true,
+        "deploymentTarget": "production",
+        "automationWorkflowId": "ops-notify"
+      }'
+```
+
+Bu çağrı aşağıdaki adımları gerçekleştirir:
+
+1. GitHub, Hostinger ve n8n bağlantılarının aktif olduğunu doğrular.
+2. Her platform için derleme kaydı oluşturur ve sürümle ilişkilendirir.
+3. Derlemeleri kuyruğa alır, otomasyon kuyruğunu boşaltarak artefact URL’lerini üretir.
+4. Sürüm durumunu `in_review` seviyesine terfi ettirir ve mağaza durumlarını günceller.
+5. Hostinger dağıtımını `production` ortamına tetikler ve n8n iş akışıyla operasyon ekibini bilgilendirir.
+
+`GET /api/pipeline/runs` çağrısı ile pipeline geçmişini, `GET /api/pipeline/runs/detail?id=pipeline_...` ile tekil yürütmenin ayrıntılarını görüntüleyebilirsiniz.
 
 ### Testleri Çalıştırma
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 App Lab Agent, yapay zeka destekli ajan orkestrasyonunu, otomasyonları ve çoklu platform dağıtımını bir arada sunarak ekiplerin fikirden yayınlamaya kadar tüm uygulama yaşam döngüsünü tek bir yerden yönetmesini sağlayan bulut tabanlı bir geliştirme platformudur. Platform, GitHub, Hostinger, n8n, analitik servisleri ve üçüncü parti yapay zeka ajanları gibi farklı hesap ve hizmetleri entegre ederek hem test hem de uygulama geliştirme süreçlerini uçtan uca otomatikleştirir.
 
+Ürün, Hostinger altyapısında barındırılan `applabagent.net` alan adı üzerinden hizmet verir ve alan adı yapılandırması, otomasyon tetikleri ile mobil mağaza yayın akışları tek bir orkestrasyon katmanında toparlanır.
+
 ## Ürün Vizyonu
 
 - **Fikirden mağazaya tek platform:** Ürün keşfi, prototipleme, geliştirme, test, sürümleme ve mağaza yayınlarını aynı çatı altında toplar.
@@ -132,6 +134,9 @@ Varsayılan olarak `http://localhost:4000` adresinde çalışan sunucu aşağıd
 - `POST /api/workflows/:id/attach-task` — İş akışını mevcut ajan görevleriyle ilişkilendirir.
 - `POST /api/workflows/:id/trigger` — İş akışını bağlam verisiyle kuyruğa alarak çalıştırır.
 - `GET /api/workflows` — Kayıtlı iş akışlarının listesini döndürür.
+- `GET /api/environment` — Platformun alan adı, Hostinger bağlantısı ve yayın kanalı özetini döndürür.
+- `POST /api/environment/domain` — Alan adını günceller ve Hostinger bağlantısını `applabagent.net` ile senkronize eder.
+- `POST /api/environment/releases` — Android/iOS/web yayın kanallarını kaydeder.
 
 Tüm uç noktalar JSON isteği kabul eder ve örnek akışları simüle etmek üzere bellek içi durum deposu kullanır.
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ Varsayılan olarak `http://localhost:4000` adresinde çalışan sunucu aşağıd
 - `POST /api/pipeline/execute` — Oluşturulan planı çalıştırır, derlemeleri kuyruğa alır, sürümü terfi ettirir ve isteğe bağlı dağıtımı tetikler.
 - `GET /api/pipeline/runs` — Kaydedilen pipeline yürütmelerinin özetini güncel zamana göre sıralı döndürür.
 - `GET /api/pipeline/runs/detail?id=` — Belirli bir pipeline kaydının entegrasyon, sürüm ve dağıtım adımlarını gösterir.
+- `GET /api/status/summary` — Tüm entegrasyon, proje, derleme ve sürüm kayıtlarının tek bir durumda özetini verir.
+- `GET /api/status/recent-activity?limit=` — En güncel pipeline, sürüm, derleme ve ajan etkinliklerini limit parametresiyle sıralar.
 
 Tüm uç noktalar JSON isteği kabul eder ve örnek akışları simüle etmek üzere bellek içi durum deposu kullanır.
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,11 @@ Varsayılan olarak `http://localhost:4000` adresinde çalışan sunucu aşağıd
 - `GET /api/environment` — Platformun alan adı, Hostinger bağlantısı ve yayın kanalı özetini döndürür.
 - `POST /api/environment/domain` — Alan adını günceller ve Hostinger bağlantısını `applabagent.net` ile senkronize eder.
 - `POST /api/environment/releases` — Android/iOS/web yayın kanallarını kaydeder.
+- `POST /api/builds` — Bir projenin Android/iOS derleme kaydını oluşturur ve kuyruğa hazırlar.
+- `POST /api/builds/:id/trigger` — Oluşturulan derlemeyi otomasyon kuyruğuna gönderir.
+- `PATCH /api/builds/:id/status` — Derleme durumunu manuel olarak günceller ve geçmişe not ekler.
+- `GET /api/builds` — Derlemeleri proje, platform veya duruma göre filtreler.
+- `GET /api/builds/:id` — Tekil derlemenin durumunu, artefact bağlantısını ve geçmişini döndürür.
 
 Tüm uç noktalar JSON isteği kabul eder ve örnek akışları simüle etmek üzere bellek içi durum deposu kullanır.
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ Varsayılan olarak `http://localhost:4000` adresinde çalışan sunucu aşağıd
 - `POST /api/projects/:id/tasks` — Projenin otomasyon görevlerini çalışma politikalarıyla ilişkilendirir.
 - `GET /api/projects` — Kayıtlı tüm projelerin özet listesini döndürür.
 - `GET /api/projects/:id` — Tekil bir projenin ayrıntılı yapılandırmasını getirir.
+- `POST /api/workflows` — Otomasyon iş akışını kaydeder ve proje/ajan bağlamı ile saklar.
+- `POST /api/workflows/:id/attach-task` — İş akışını mevcut ajan görevleriyle ilişkilendirir.
+- `POST /api/workflows/:id/trigger` — İş akışını bağlam verisiyle kuyruğa alarak çalıştırır.
+- `GET /api/workflows` — Kayıtlı iş akışlarının listesini döndürür.
 
 Tüm uç noktalar JSON isteği kabul eder ve örnek akışları simüle etmek üzere bellek içi durum deposu kullanır.
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,151 @@
-# AppLabAgent
-App Lab Agent bir yapay zeka ajanlarını kullnarak insanların hem test hem uygulama yapabilecekleri hesapları baglayıp github hostinger n8n otomasyanlarını ve diğe ryapay zeka ajanlarını kullanıp uygulama cıkarbilecekleri bir uygulama geliştirme firmasına ait ve domain hosting ve kendi uygulamalarını geliştirdikleri bir uygulama 
+# App Lab Agent
+
+App Lab Agent, yapay zeka destekli ajan orkestrasyonunu, otomasyonları ve çoklu platform dağıtımını bir arada sunarak ekiplerin fikirden yayınlamaya kadar tüm uygulama yaşam döngüsünü tek bir yerden yönetmesini sağlayan bulut tabanlı bir geliştirme platformudur. Platform, GitHub, Hostinger, n8n, analitik servisleri ve üçüncü parti yapay zeka ajanları gibi farklı hesap ve hizmetleri entegre ederek hem test hem de uygulama geliştirme süreçlerini uçtan uca otomatikleştirir.
+
+## Ürün Vizyonu
+
+- **Fikirden mağazaya tek platform:** Ürün keşfi, prototipleme, geliştirme, test, sürümleme ve mağaza yayınlarını aynı çatı altında toplar.
+- **Ajan destekli üretkenlik:** Kod üretimi, test senaryoları, QA raporları, içerik lokalizasyonu gibi görevler yapay zeka ajanlarıyla otomatikleşir.
+- **Otomasyonla güvenli ölçeklenebilirlik:** GitHub akışları, Hostinger dağıtımları ve n8n tabanlı iş akışları sayesinde tekrar eden görevler kodsuz olarak yönetilir.
+- **Çoklu platform dağıtımı:** Android, iOS ve web uygulamaları tek kod tabanından oluşturulur, test edilir ve dağıtılır.
+
+## Ana Yetenekler
+
+| Alan | Özellikler |
+| --- | --- |
+| Hesap Entegrasyonu | OAuth 2.0 tabanlı bağlantılar, rol bazlı yetki devirleri, audit logları |
+| Yapay Zeka Ajanları | Kod asistanları, test ajanı, yayın asistanı, operasyon analisti |
+| Otomasyon | n8n senaryoları, GitHub Actions, Hostinger API entegrasyonları |
+| Test & QA | Otomatik test üretimi, cihaz çiftliği entegrasyonu, kullanıcı kabul testleri |
+| Yayın & Pazarlama | Android APK/AAB üretimi, iOS TestFlight, App Store & Google Play teslimi |
+| İzleme & Operasyon | Canlı sağlık kontrolleri, Log toplama, uyarı panelleri |
+
+## Modüler Mimari
+
+```
+┌────────────────────┐     ┌────────────────────┐
+│  Kullanıcı Portalı │◄───►│  Yetkilendirme     │
+└────────┬───────────┘     └─────────┬──────────┘
+         │                            │
+         ▼                            ▼
+┌────────────────────┐     ┌────────────────────┐
+│  Ajan Orkestratörü │◄───►│  İş Akışı Motoru   │
+└────────┬───────────┘     └─────────┬──────────┘
+         │                            │
+         ▼                            ▼
+┌────────────────────┐     ┌────────────────────┐
+│  App Builder       │◄───►│  Dağıtım Merkezi   │
+└────────────────────┘     └────────────────────┘
+```
+
+### 1. Kullanıcı Portalı
+- Organizasyon yönetimi, proje panelleri ve görev atamaları sağlar.
+- Ekip rolleri ve erişim kontrolü için RBAC modeli uygular.
+
+### 2. Yetkilendirme Katmanı
+- GitHub, Hostinger, n8n ve diğer SaaS servisleriyle güvenli anahtar yönetimi sunar.
+- OAuth 2.0 ve API anahtar kasasıyla audit trail oluşturur.
+
+### 3. Ajan Orkestratörü
+- Çoklu yapay zeka ajanlarını tek koordinasyon katmanında toplar.
+- Görev önceliklendirme, mesajlaşma, hata toleransı ve model seçimi kurallarını içerir.
+
+### 4. İş Akışı Motoru (n8n + Özel Akışlar)
+- Kod oluşturma, test planı, dağıtım ve raporlama senaryolarını tetikler.
+- İnsan onayı gerektiren adımlar için bekleme durumları ve SLA takibi yapar.
+
+### 5. App Builder
+- Flutter/React Native tabanlı çapraz platform şablonları yönetir.
+- Modül, sayfa ve bileşen bazlı sürükle-bırak düzenleme sağlar.
+
+### 6. Dağıtım Merkezi
+- Hostinger üzerinde staging/live ortamlarına otomatik yayın yapar.
+- GitHub Actions ile CI/CD, Firebase App Distribution, TestFlight ve Play Console entegrasyonlarını yönetir.
+
+## Kullanım Senaryoları
+
+1. **Yeni ürün keşfi:** Ürün sahibi özellikleri tanımlar, ajanlar ürün gereksinim belgelerini ve kullanıcı hikâyelerini üretir.
+2. **Otomatik prototipleme:** Tasarım ajanı ekran akışlarını oluşturur, App Builder prototipleri derler.
+3. **Kod üretimi & test:** Kod ajanı modüler kod parçaları üretir, test ajanı otomatik senaryolar ve raporlar oluşturur.
+4. **Dağıtım & yayın:** CI/CD hattı APK/AAB ve IPA paketlerini oluşturur; yayın ajanı mağaza listinglerini günceller.
+5. **Operasyon & bakım:** Canlı izleme, hata ayıklama ajanları, kullanıcı geri bildirim döngüleri.
+
+## Teknoloji Yığını
+
+- **Ön yüz:** Flutter (mobil), Next.js (web), Tailwind CSS, Storybook.
+- **Arka uç:** Node.js (NestJS), GraphQL API, PostgreSQL, Redis, Hasura.
+- **Ajan Katmanı:** LangChain, OpenAI/GPT, Hugging Face Hub, özel LLM barındırmaları.
+- **Otomasyon:** n8n, Temporal.io, GitHub Actions, Terraform, Docker, Kubernetes.
+- **Dağıtım:** Hostinger VPS/Kubernetes, Firebase App Distribution, App Store Connect API, Google Play Developer API.
+- **İzleme:** Grafana, Prometheus, Sentry, Elastic Stack.
+
+## Güvenlik ve Uyumluluk
+
+- Zero-trust erişim modeli, SSO entegrasyonları (Okta, Azure AD).
+- Şifreleme: Transit (TLS 1.3), at-rest (AES-256), gizlilik için gizli anahtar kasaları.
+- Denetim: SOC2, ISO 27001 uyum hedefleri, günlük saklama politikaları.
+
+## Yol Haritası
+
+| Çeyrek | Başlık | Açıklama |
+| --- | --- | --- |
+| Q1 | Çekirdek platform | Ajan orkestratörü, proje yönetimi ve GitHub entegrasyonu |
+| Q2 | Otomasyon genişletme | n8n şablon kütüphanesi, Hostinger dağıtımı, test çiftliği entegrasyonu |
+| Q3 | Mobil dağıtım | Android/iOS yayın hattı, mağaza içeriği otomasyonu |
+| Q4 | Pazarlama & Analitik | Kullanıcı segmentasyonu, kampanya ajanları, ürün analitiği |
+
+## Başlangıç Rehberi
+
+1. **Organizasyon oluştur:** Çoklu ekip ve proje yapısını tanımla.
+2. **Hesapları bağla:** GitHub, Hostinger, n8n, analitik ve üçüncü parti ajan sağlayıcılarını OAuth ile bağla.
+3. **Şablon seç:** App Builder içindeki hazır şablonlardan veya boş projeden başla.
+4. **Ajanları yapılandır:** Görev bazlı ajan profilleri, yetkiler ve gözlem parametrelerini ata.
+5. **İş akışlarını çalıştır:** n8n senaryolarıyla otomatik kod üretimi, test ve dağıtım adımlarını tetikle.
+6. **Dağıt ve izle:** Mobil paketleri üret, mağazalara gönder, operasyon panellerinden performansı takip et.
+
+## Referans Uygulama İskeleti
+
+Depoda, App Lab Agent mimarisini kavramsal olarak göstermek amacıyla Node.js tabanlı hafif bir HTTP sunucusu yer alır. Bu iskelet,
+entegrasyon durumlarını simüle eder ve ajan görevlerinin n8n iş akışları ile Hostinger dağıtımlarına nasıl bağlanacağını örnekler.
+
+### Sunucuyu Çalıştırma
+
+```bash
+npm install
+npm start
+```
+
+Varsayılan olarak `http://localhost:4000` adresinde çalışan sunucu aşağıdaki uç noktaları sağlar:
+
+- `POST /api/integrations/github/connect` — GitHub bağlantısını kaydeder.
+- `POST /api/integrations/hostinger/deploy` — Hostinger üzerinde yayın tetikler.
+- `POST /api/integrations/n8n/trigger` — n8n iş akışını simüle eder.
+- `POST /api/tasks` — Ajan görevini kaydeder.
+- `POST /api/tasks/:id/dispatch` — Görevi kuyruğa alır.
+- `POST /api/queue/process` — Kuyruktaki ilk görevi işleyerek n8n ve Hostinger tetiklerini çalıştırır.
+- `POST /api/projects` — Yeni bir proje kaydı oluşturur ve açıklama ekler.
+- `POST /api/projects/:id/integrations` — Projeyi GitHub, Hostinger, n8n gibi entegrasyonlara bağlar.
+- `POST /api/projects/:id/tasks` — Projenin otomasyon görevlerini çalışma politikalarıyla ilişkilendirir.
+- `GET /api/projects` — Kayıtlı tüm projelerin özet listesini döndürür.
+- `GET /api/projects/:id` — Tekil bir projenin ayrıntılı yapılandırmasını getirir.
+
+Tüm uç noktalar JSON isteği kabul eder ve örnek akışları simüle etmek üzere bellek içi durum deposu kullanır.
+
+### Testleri Çalıştırma
+
+```bash
+npm test
+```
+
+`node:test` tabanlı senaryolar, entegrasyonların ve otomasyon kuyruğunun beklendiği gibi davrandığını doğrular.
+
+## Dokümantasyon
+
+- [Ürün Genel Bakışı](docs/product-overview.md)
+- [Teknik Mimari](docs/technical-architecture.md)
+- [Otomasyon Senaryoları](docs/automation-blueprints.md)
+- [Mobil Dağıtım Kılavuzu](docs/mobile-distribution.md)
+
+---
+
+App Lab Agent, geliştiricilerin ve ürün ekiplerinin üretkenliğini artırmak için oluşturulmuş modern ve güvenli bir platformdur. Bu depo, platform mimarisini, otomasyon stratejilerini ve uçtan uca yayın sürecini belgelemek için kullanılacaktır.

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Varsayılan olarak `http://localhost:4000` adresinde çalışan sunucu aşağıd
 
 - `POST /api/integrations/github/connect` — GitHub bağlantısını kaydeder.
 - `POST /api/integrations/hostinger/deploy` — Hostinger üzerinde yayın tetikler.
+- `GET /api/integrations/hostinger/virtual-machines` — Hostinger VPS envanterini canlı API üzerinden çeker.
 - `POST /api/integrations/n8n/trigger` — n8n iş akışını simüle eder.
 - `POST /api/tasks` — Ajan görevini kaydeder.
 - `POST /api/tasks/:id/dispatch` — Görevi kuyruğa alır.
@@ -206,3 +207,5 @@ npm test
 ---
 
 App Lab Agent, geliştiricilerin ve ürün ekiplerinin üretkenliğini artırmak için oluşturulmuş modern ve güvenli bir platformdur. Bu depo, platform mimarisini, otomasyon stratejilerini ve uçtan uca yayın sürecini belgelemek için kullanılacaktır.
+
+Hostinger API çağrıları varsayılan olarak `https://developers.hostinger.com` taban adresini kullanır; farklı ortamlarda `HOSTINGER_API_BASE_URL` ortam değişkeniyle özelleştirilebilir ve isteklerde `apiKey` sorgu parametresi gönderilmediğinde kayıtlı bağlantıdaki anahtar kullanılır.

--- a/README.md
+++ b/README.md
@@ -142,6 +142,12 @@ Varsayılan olarak `http://localhost:4000` adresinde çalışan sunucu aşağıd
 - `PATCH /api/builds/:id/status` — Derleme durumunu manuel olarak günceller ve geçmişe not ekler.
 - `GET /api/builds` — Derlemeleri proje, platform veya duruma göre filtreler.
 - `GET /api/builds/:id` — Tekil derlemenin durumunu, artefact bağlantısını ve geçmişini döndürür.
+- `POST /api/releases` — Çoklu platform sürüm kaydını oluşturur ve platform varsayılanlarını ayarlar.
+- `GET /api/releases` — Sürüm özetlerini proje bazında listeler.
+- `GET /api/releases/:id` — Seçilen sürümün platform durumları ve tarihçesini döndürür.
+- `POST /api/releases/:id/platforms` — Platforma build bağlar veya mağaza durumunu günceller.
+- `POST /api/releases/:id/promote` — Sürüm durumunu (draft, in_progress, published vb.) değiştirir.
+- `POST /api/releases/:id/timeline` — Serbest metin kilometre taşı mesajlarını sürüm geçmişine ekler.
 
 Tüm uç noktalar JSON isteği kabul eder ve örnek akışları simüle etmek üzere bellek içi durum deposu kullanır.
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ Varsayılan olarak `http://localhost:4000` adresinde çalışan sunucu aşağıd
 - `POST /api/tasks` — Ajan görevini kaydeder.
 - `POST /api/tasks/:id/dispatch` — Görevi kuyruğa alır.
 - `POST /api/queue/process` — Kuyruktaki ilk görevi işleyerek n8n ve Hostinger tetiklerini çalıştırır.
+- `POST /api/agents` — Yapay zeka ajan profilini oluşturur ve varsayılan yetenekleri kaydeder.
+- `GET /api/agents` — Kayıtlı ajan profillerini proje filtresiyle birlikte döndürür.
+- `GET /api/agents/:id` — Tek bir ajan profilinin sağlayıcı, model ve talimat detaylarını getirir.
+- `PATCH /api/agents/:id` — Ajan profilinin yeteneklerini veya talimatlarını günceller.
+- `POST /api/agents/:id/link` — Ajanı belirli bir projeye bağlar ve görev havuzunda önceliklendirir.
+- `DELETE /api/agents/:id` — Ajan profilini ve ilişkili meta veriyi kaldırır.
 - `POST /api/projects` — Yeni bir proje kaydı oluşturur ve açıklama ekler.
 - `POST /api/projects/:id/integrations` — Projeyi GitHub, Hostinger, n8n gibi entegrasyonlara bağlar.
 - `POST /api/projects/:id/tasks` — Projenin otomasyon görevlerini çalışma politikalarıyla ilişkilendirir.

--- a/README_COMPLETE.md
+++ b/README_COMPLETE.md
@@ -1,0 +1,205 @@
+# AppLab Agent Platform
+
+## 🚀 Modern AI-Powered Development Platform
+
+AppLab Agent, AI destekli uygulama geliştirme ve deployment platformudur. Geliştiricilerin projelerini hızla oluşturmasına, yönetmesine ve deploy etmesine yardımcı olur.
+
+## ✨ Özellikler
+
+### 🤖 AI Destekli Geliştirme
+- **AI Code Generation**: Kod otomatik oluşturma
+- **Code Analysis**: Akıllı kod analizi ve öneriler
+- **AI Chat**: Geliştirme sürecinde AI asistan desteği
+- **Smart Templates**: AI destekli proje şablonları
+
+### 👥 Kullanıcı Yönetimi
+- **Authentication**: JWT tabanlı güvenli kimlik doğrulama
+- **User Profiles**: Kapsamlı kullanıcı profil yönetimi
+- **Role-based Access**: Rol tabanlı erişim kontrolü
+- **API Rate Limiting**: Kullanıcı bazlı API kullanım limitleri
+
+### 📊 Analytics & Monitoring
+- **Real-time Analytics**: Gerçek zamanlı kullanım analytics
+- **Performance Monitoring**: Sistem performans takibi
+- **Usage Statistics**: Detaylı kullanım istatistikleri
+- **Custom Metrics**: Özelleştirilebilir metrikler
+
+### 🔔 Bildirim Sistemi
+- **Multi-channel Notifications**: Email, SMS, Push notifications
+- **Real-time Alerts**: Anlık bildirimler
+- **Custom Templates**: Özelleştirilebilir bildirim şablonları
+- **Notification Preferences**: Kullanıcı tercih yönetimi
+
+### 📁 Dosya Yönetimi
+- **Secure File Upload**: Güvenli dosya yükleme
+- **Multi-format Support**: Çoklu dosya formatı desteği
+- **File Validation**: Dosya doğrulama ve güvenlik
+- **Cloud Storage Ready**: Bulut depolama entegrasyon hazır
+
+### 🔌 WebSocket Desteği
+- **Real-time Communication**: Gerçek zamanlı iletişim
+- **Live Updates**: Canlı güncellemeler
+- **Chat Systems**: Chat sistem desteği
+- **Event Broadcasting**: Event yayını
+
+## 🏗️ Teknik Mimari
+
+### Backend
+- **Node.js + Express**: Modern web framework
+- **JWT Authentication**: Güvenli kimlik doğrulama
+- **PostgreSQL Ready**: Ölçeklenebilir veritabanı desteği
+- **RESTful API**: Standart REST API yapısı
+- **Comprehensive Logging**: Detaylı log sistemi
+- **Error Handling**: Kapsamlı hata yönetimi
+
+### Frontend Ready
+- **Next.js Support**: Modern React framework desteği
+- **TypeScript**: Type-safe development
+- **Responsive Design**: Mobil uyumlu tasarım
+
+## 📦 Kurulum
+
+### Gereksinimler
+- Node.js (v16+)
+- PostgreSQL (opsiyonel)
+- npm veya yarn
+
+### Hızlı Başlangıç
+
+1. **Repository'yi klonlayın:**
+```bash
+git clone https://github.com/nikocan/AppLabAgent.git
+cd AppLabAgent
+```
+
+2. **Dependencies yükleyin:**
+```bash
+npm install
+```
+
+3. **Environment variables ayarlayın:**
+```bash
+cp .env.example .env
+# .env dosyasını ihtiyaçlarınıza göre düzenleyin
+```
+
+4. **Sunucuyu başlatın:**
+```bash
+npm start
+```
+
+5. **API'yi test edin:**
+```bash
+curl http://localhost:3000/health
+```
+
+## 🔧 API Endpoints
+
+### Authentication
+```bash
+POST /api/user/register  # Kullanıcı kaydı
+POST /api/user/login     # Kullanıcı girişi  
+GET  /api/user/profile   # Profil bilgileri
+PUT  /api/user/profile   # Profil güncelle
+```
+
+### AI Services
+```bash
+POST /api/ai/agents      # AI Agent oluştur
+POST /api/ai/chat        # AI Chat
+```
+
+### Health Check
+```bash
+GET  /health             # Sistem durumu
+```
+
+## 🚀 Deployment
+
+### Development
+```bash
+npm run dev
+```
+
+### Production
+```bash
+npm run build
+npm start
+```
+
+### Docker (Coming Soon)
+```bash
+docker-compose up
+```
+
+## 📱 Mobile Support
+
+Platform, gelecekte mobil uygulama deployment'ı için hazır:
+- iOS App Store deployment
+- Google Play Store deployment
+- React Native support
+- Flutter support
+- Hybrid app solutions
+
+## 🔒 Güvenlik
+
+- JWT token authentication
+- Password hashing (bcrypt)
+- Input validation
+- Rate limiting
+- CORS protection
+- SQL injection prevention
+
+## 📈 Performans
+
+- Optimized database queries
+- Caching mechanisms ready
+- Load balancing ready
+- CDN integration ready
+- Performance monitoring
+
+## 🛠️ Geliştirme
+
+### Code Style
+```bash
+npm run lint      # Code linting
+npm run format    # Code formatting
+```
+
+### Testing
+```bash
+npm test          # Run tests
+npm run coverage  # Test coverage
+```
+
+## 📚 Dokümantasyon
+
+- [API Documentation](docs/api.md)
+- [Technical Architecture](docs/technical-architecture.md)
+- [Deployment Guide](docs/deployment.md)
+- [Development Guide](docs/development.md)
+
+## 🤝 Katkıda Bulunma
+
+1. Fork edin
+2. Feature branch oluşturun (`git checkout -b feature/amazing-feature`)
+3. Commit edin (`git commit -m 'Add some amazing feature'`)
+4. Push edin (`git push origin feature/amazing-feature`)
+5. Pull Request oluşturun
+
+## 📄 Lisans
+
+Bu proje MIT lisansı altında lisanslanmıştır. Detaylar için [LICENSE](LICENSE) dosyasına bakın.
+
+## 🌟 Teşekkürler
+
+AppLab Agent'ı kullandığınız için teşekkür ederiz! 
+
+## 📞 İletişim
+
+- **GitHub**: [nikocan/AppLabAgent](https://github.com/nikocan/AppLabAgent)
+- **Issues**: [GitHub Issues](https://github.com/nikocan/AppLabAgent/issues)
+
+---
+
+**AppLab Agent** - AI ile geleceğin uygulamalarını bugünden geliştirin! 🚀

--- a/docs/automation-blueprints.md
+++ b/docs/automation-blueprints.md
@@ -1,0 +1,92 @@
+# Otomasyon Senaryoları
+
+Bu doküman, App Lab Agent platformunda kullanılan n8n ve GitHub Actions tabanlı otomasyon akışlarını tanımlar. Amaç, her bir iş akışının tetikleyicilerini, adımlarını ve çıktısını standart bir formatta belgelemektir.
+
+## n8n Akış Şablonları
+
+### 1. Kod Üretimi & Pull Request Akışı
+- **Tetikleyici:** Proje panosunda "Kod Üret" görevinin tamamlanması.
+- **Adımlar:**
+  1. Görev detaylarını GraphQL API’den al.
+  2. Kod ajanını çağır, önerilen değişiklikleri al.
+  3. GitHub branch oluştur, dosya güncellemelerini uygula.
+  4. PR şablonu doldur, ilgili ekibe bildirim gönder.
+- **Çıktı:** Otomatik oluşturulmuş PR, Slack/Jira bildirimi.
+
+### 2. Test Pipeline Senaryosu
+- **Tetikleyici:** GitHub PR açılması veya güncellenmesi.
+- **Adımlar:**
+  1. GitHub Actions pipeline durumunu izle.
+  2. Cihaz çiftliği (Firebase Test Lab) testlerini başlat.
+  3. Test sonuçlarını topla, rapor ajanına ilet.
+  4. Başarısız testlerde görev aç, ekibi uyar.
+- **Çıktı:** Test raporu, JIRA/Linear görevi, Slack bildirimi.
+
+### 3. Yayın Hazırlığı Akışı
+- **Tetikleyici:** "Release" etiketi oluşturulması.
+- **Adımlar:**
+  1. Sürüm notu ajanı ile değişiklik listesi oluştur.
+  2. Fastlane komutlarını tetikle (Android/iOS).
+  3. App Store Connect ve Google Play’e paket yükle.
+  4. Hostinger staging/live ortamlarını güncelle.
+- **Çıktı:** Yayınlanan sürüm, güncellenmiş mağaza içerikleri, dağıtım raporu.
+
+### 4. Pazarlama Kampanyası Akışı
+- **Tetikleyici:** Yeni sürüm yayını.
+- **Adımlar:**
+  1. Pazarlama ajanı ile kampanya metinleri oluştur.
+  2. E-posta otomasyon sistemlerine (Brevo, Mailchimp) gönder.
+  3. Sosyal medya planlayıcılarına (Buffer) içerik ekle.
+  4. Analitik ajanı için UTM parametrelerini oluştur.
+- **Çıktı:** Kampanya gönderileri, performans izleme panelleri.
+
+## GitHub Actions Pipeline’ları
+
+| Pipeline | Açıklama | Önemli Adımlar |
+| --- | --- | --- |
+| `build-test.yml` | Kod derleme ve testleri çalıştırır | Node setup, Flutter build, Jest/Unit testler, rapor yükleme |
+| `deploy-hostinger.yml` | Hostinger ortamlarına dağıtım yapar | Terraform plan/apply, Docker push, SSH deploy |
+| `release-mobile.yml` | Mobil paket üretimi ve mağazalara yükleme | Fastlane lanes, App Store Connect API, Google Play API |
+| `security-scan.yml` | Güvenlik ve lisans taramaları | Snyk/Trivy, Dependabot raporları |
+
+## Otomasyon İlkeleri
+
+1. **İzlenebilirlik:** Her otomasyon adımı loglanmalı ve portalda görünmelidir.
+2. **İnsan Onayı:** Kritik dağıtım adımlarında manuel onay katmanı bulunmalıdır.
+3. **Tekrarlanabilirlik:** Şablonlar versiyonlanmalı, değişiklikler review sürecinden geçmelidir.
+4. **Hata Geri Bildirimi:** Hatalar otomatik olarak ilgili ekibe yönlendirilmelidir.
+5. **Güvenlik:** Gizli anahtarlar Vault’da tutulmalı, minimum izin prensibi uygulanmalıdır.
+
+## Örnek n8n Node Konfigürasyonları
+
+```json
+{
+  "name": "GitHub API Call",
+  "type": "n8n-nodes-base.httpRequest",
+  "parameters": {
+    "url": "https://api.github.com/repos/{{ $json.repo }}/pulls",
+    "method": "POST",
+    "authentication": "oAuth2"
+  }
+}
+```
+
+```json
+{
+  "name": "Hostinger Deploy",
+  "type": "n8n-nodes-base.ssh",
+  "parameters": {
+    "command": "deploy_app.sh {{ $json.releaseTag }}",
+    "sshAuthentication": "keyPair"
+  }
+}
+```
+
+## İzleme & Alarmlar
+
+- n8n, Prometheus exporter ile iş akışı metriklerini yayınlar.
+- Pipeline başarısızlıkları için PagerDuty/Slack uyarıları kurulur.
+- Başarılı dağıtımlar sonrası rapor ajanı, e-posta ve portal bildirimleri gönderir.
+
+---
+Tüm otomasyon şablonları `automation/` klasöründe versiyonlanmalı ve değişiklikler kod incelemesinden geçmelidir.

--- a/docs/mobile-distribution.md
+++ b/docs/mobile-distribution.md
@@ -1,0 +1,81 @@
+# Mobil Dağıtım Kılavuzu
+
+Bu doküman, App Lab Agent platformunun Android ve iOS dağıtım süreçlerini ve otomasyon adımlarını açıklar. Kullanıcıların uygulamalarını mağazalara güvenli ve hızlı bir şekilde yükleyebilmeleri için gerekli konfigürasyon detaylarını içerir.
+
+## Ön Koşullar
+
+- Google Play Developer hesabı ve servis hesabı JSON anahtarı
+- Apple Developer Program üyeliği, App Store Connect API anahtarları
+- Hostinger üzerinde yapı artefaktlarını barındırmak için güvenli depolama
+- Fastlane kurulumları ve CI ortamı erişimi
+
+## Android Dağıtım Süreci
+
+1. **Versiyonlama**
+   - `pubspec.yaml` veya `app/build.gradle` dosyasında sürüm numarası güncellenir.
+   - Sürüm kodu (versionCode) CI pipeline tarafından otomatik artırılır.
+2. **Build**
+   - Flutter `build appbundle` komutu veya Native projelerde `gradlew bundleRelease`.
+   - Artifaktlar `build/outputs` klasöründe toplanır.
+3. **İmza**
+   - Keystore dosyası Vault’dan çekilir, CI ortamında decrypt edilir.
+   - `jarsigner` veya `gradle` signing config ile imzalama yapılır.
+4. **Yükleme**
+   - Fastlane `supply` komutu kullanılarak Google Play’e yükleme yapılır.
+   - Hedef kanallar: Internal, Closed, Open testing ve Production.
+5. **Mağaza İçeriği**
+   - Ekran görüntüleri, özellik grafikleri, açıklamalar içerik ajanı tarafından güncellenir.
+6. **Dağıtım Sonrası**
+   - Play Console API’sinden durum kontrolü, hata varsa otomatik geri bildirim.
+
+## iOS Dağıtım Süreci
+
+1. **Versiyonlama**
+   - `pubspec.yaml` veya Xcode `Info.plist` içerisinde `CFBundleShortVersionString` güncellenir.
+   - Build numarası CI tarafından artırılır (Fastlane `increment_build_number`).
+2. **Build**
+   - `flutter build ipa` veya Xcode `xcodebuild -scheme Release`.
+   - Artifaktlar `build/ios/ipa` klasöründe saklanır.
+3. **İmza & Profil**
+   - Sertifikalar ve provisioning profilleri Fastlane Match ile yönetilir.
+   - CI ortamında anahtarlar decrypt edilerek kullanılabilir.
+4. **Yükleme**
+   - Fastlane `deliver` veya `pilot` ile TestFlight ve App Store Connect yüklemesi yapılır.
+   - Metadata otomatik güncellenir, otomatik screenshot yükleme desteklenir.
+5. **İnceleme Süreci**
+   - App Store inceleme notları, uyumluluk belgeleri ajan tarafından hazırlanan şablonlarla sunulur.
+   - İnceleme durumları Slack/Jira entegrasyonlarıyla izlenir.
+
+## Ortak CI/CD Adımları
+
+- GitHub Actions tetikleyici: `push` veya `workflow_dispatch`.
+- Build matrix: Android (Linux runner), iOS (macOS runner).
+- Artefakt saklama: GitHub Artifacts, Hostinger S3 uyumlu depo.
+- Güvenlik: Fastlane için `APP_STORE_CONNECT_API_KEY`, `GOOGLE_PLAY_JSON_KEY` gibi gizliler Vault’dan alınır.
+- Bildirimler: Slack, Teams, e-posta.
+
+## Mağaza Yayın Kontrolleri
+
+| Kontrol | Android | iOS |
+| --- | --- | --- |
+| Uygulama İçi Gizlilik | Data Safety formu güncel mi? | Privacy manifest, ATT açıklamaları |
+| İzinler | Manifest izinleri doğrulandı mı? | Info.plist izin açıklamaları |
+| Test Cihazları | Internal testers güncel mi? | TestFlight internal testers |
+| Sürüm Notları | Sürüm notu ajanı güncelledi mi? | Release notes deliver edildi mi? |
+| Çeviriler | Lokalizasyon paketleri eksiksiz mi? | Lokalizasyon dosyaları güncel mi? |
+
+## Sorun Giderme
+
+- **İmza Hataları:** Keystore/sertifika süreleri kontrol edilmeli, otomatik yenileme akışı kurulmalı.
+- **API Limitleri:** Google/Apple API kotaları izlenmeli, aşım durumunda bekleme politikaları uygulanmalı.
+- **CI Fail:** Loglar otomatik olarak Sentry’ye gönderilir, yeniden deneme stratejileri belirlenir.
+- **Mağaza Retleri:** Ajan destekli kök neden analizi ve düzeltme önerileri oluşturulur.
+
+## Yayın Sonrası İzleme
+
+- Crash ve performans metrikleri: Firebase Crashlytics, Sentry, App Store Connect Analytics.
+- Kullanıcı yorumları: Google Play & App Store API ile çekilir, yanıtlar ajan tarafından taslaklanır.
+- A/B testleri: Firebase Remote Config, App Store Product Page Optimization.
+
+---
+Bu kılavuz, mobil dağıtım süreçlerinin standartlaşmasını sağlar. Güncellemeler yapıldığında CI/CD ve otomasyon ekipleri bilgilendirilmelidir.

--- a/docs/product-overview.md
+++ b/docs/product-overview.md
@@ -14,6 +14,7 @@ App Lab Agent, uygulama geliştirme ekiplerinin fikir, tasarım, geliştirme, te
 
 - **Tek noktadan yönetim:** Çoklu servis bağlantıları tek panelden kontrol edilir.
 - **Özelleştirilebilir ajanlar:** Görev bazlı davranış kuralları ve yetkilendirme seviyeleri tanımlanabilir.
+- **Ajan profili kitaplığı:** Proje bazlı ajan atamaları, rol şablonları ve talimat havuzları tek merkezden yönetilir.
 - **Hızlı prototipleme:** Hazır şablonlar ve kod üretim ajanlarıyla MVP süreleri kısalır.
 - **Sürekli test:** Cihaz çiftliği entegrasyonları sayesinde regresyon süreçleri hızlanır.
 - **Otomatik yayın:** Google Play, App Store, Hostinger ortamları tek tıklamayla güncellenir.

--- a/docs/product-overview.md
+++ b/docs/product-overview.md
@@ -1,0 +1,73 @@
+# Ürün Genel Bakışı
+
+App Lab Agent, uygulama geliştirme ekiplerinin fikir, tasarım, geliştirme, test, dağıtım ve operasyon süreçlerini yapay zeka ajanları ve otomasyon senaryolarıyla hızlandıran uçtan uca bir platformdur. Bu doküman, platformun hedeflediği kullanıcı profillerini, değer önerilerini ve kritik kullanıcı yolculuklarını açıklar.
+
+## Kullanıcı Profilleri
+
+1. **Ürün Sahibi (PO):** Özellik önceliklendirmesi, gereksinim yönetimi ve yayın planlamasından sorumludur.
+2. **Geliştirici:** Mobil ve web modüllerini geliştirir, kod inceleme ve test süreçlerine katılır.
+3. **QA Mühendisi:** Test senaryolarını doğrular, cihaz çiftliği sonuçlarını takip eder.
+4. **Otomasyon Uzmanı:** n8n akışlarını tasarlar, entegrasyonları yapılandırır.
+5. **Operasyon Ekibi:** Dağıtım, izleme, uyarı ve olay müdahalesini yürütür.
+
+## Değer Önerileri
+
+- **Tek noktadan yönetim:** Çoklu servis bağlantıları tek panelden kontrol edilir.
+- **Özelleştirilebilir ajanlar:** Görev bazlı davranış kuralları ve yetkilendirme seviyeleri tanımlanabilir.
+- **Hızlı prototipleme:** Hazır şablonlar ve kod üretim ajanlarıyla MVP süreleri kısalır.
+- **Sürekli test:** Cihaz çiftliği entegrasyonları sayesinde regresyon süreçleri hızlanır.
+- **Otomatik yayın:** Google Play, App Store, Hostinger ortamları tek tıklamayla güncellenir.
+
+## Kullanıcı Yolculukları
+
+### 1. Proje Başlatma
+- Organizasyon ve ekip rolleri tanımlanır.
+- GitHub reposu bağlanır, şablon seçilir.
+- Ajan orkestratörü görev dağılımlarını otomatik oluşturur.
+
+### 2. Geliştirme Sprinti
+- PO backlog oluşturur, ajanlar kullanıcı hikâyesi detaylarını genişletir.
+- Geliştirici ajanı kod önerileri ve refactoring planı sunar.
+- QA ajanı test senaryoları ve kabul kriterlerini üretir.
+
+### 3. Test & Onay
+- n8n akışı CI/CD pipeline’ını tetikler.
+- Test ajanı sonuçları raporlar, başarısızlıkta geri bildirim döngüsü açar.
+- İnsan onayı adımları gerekli durumlarda devreye alınır.
+
+### 4. Yayın ve Pazarlama
+- Yayın ajanı mağaza içeriklerini, ekran görüntülerini ve meta verileri günceller.
+- Pazarlama ajanı kampanya planları ve e-posta otomasyonları oluşturur.
+- Analitik ajanı, kullanıcı edinimi ve retention metriklerini izler.
+
+### 5. Operasyon ve Destek
+- Operasyon ajanı hataları sınıflandırır, Jira/Linear görevleri açar.
+- Sentry, Grafana ve Prometheus verileri tek panelde görselleştirilir.
+- Kullanıcı geri bildirim ajanı, anket ve değerlendirmeleri işler.
+
+## Başarı Göstergeleri
+
+| Metri̇k | Açıklama | Hedef |
+| --- | --- | --- |
+| MVP Teslim Süresi | Fikirden yayınlanan MVP’ye kadar geçen süre | %40 azalma |
+| Otomatik Test Kapsamı | Toplam testlerin otomatikleşen oranı | %80 |
+| Manuel Yayın İşlemleri | İnsan müdahalesi gerektiren yayın adımları | <%10 |
+| Kullanıcı Memnuniyeti | NPS/CSAT skorları | 8+/10 |
+| Ekip Verimliliği | Sprint başına tamamlanan hikâye sayısı | %30 artış |
+
+## Rekabet Avantajları
+
+- Çoklu ajan yönetimi için özel orkestrasyon katmanı
+- Hostinger, GitHub ve n8n için derin entegrasyonlar
+- Mobil ve web dağıtımlarını aynı pipeline’da yönetme yeteneği
+- AI tabanlı içerik, test ve operasyon destek araçları
+
+## Gelecek İyileştirmeler
+
+- Low-code editör ve tasarım sistemleriyle daha hızlı ekran üretimi
+- AI modellerinin özelleştirilmesi için AutoML altyapısı
+- Marketplace: Hazır ajan paketleri ve n8n akışları paylaşımı
+- Müşteri içgörüleri için veri gölü ve analitik paneller
+
+---
+Bu doküman, App Lab Agent’ın ürün stratejisinin temelini oluşturur ve diğer teknik belgeler için referans sağlar.

--- a/docs/technical-architecture.md
+++ b/docs/technical-architecture.md
@@ -57,6 +57,11 @@ Bu doküman, App Lab Agent platformunun yüksek seviyeli teknik mimarisini ve te
 - Prompt yönetimi ve sürümleme için özel depo
 - Erişim kontrolleri: Her ajan için scoped API anahtarları
 
+### Ajan Profili Kaydı
+- Ajan metadata deposu: sağlayıcı, model, talimat ve yetenek setleri.
+- Proje bazlı ilişkilendirme ve görev önceliklendirme bilgileri.
+- REST API ile CRUD işlemleri, orchestrator cache senkronizasyonu.
+
 ### Workflow Motoru
 - n8n node’ları: GitHub, Hostinger, Slack, Jira, Linear, Notion
 - İnsan-in-the-loop (HITL) adımları için manuel onay modülü

--- a/docs/technical-architecture.md
+++ b/docs/technical-architecture.md
@@ -1,0 +1,114 @@
+# Teknik Mimari
+
+Bu doküman, App Lab Agent platformunun yüksek seviyeli teknik mimarisini ve temel bileşenlerini açıklar. Amaç, ekiplerin altyapı kararlarını, ölçeklenebilirlik gereksinimlerini ve güvenlik prensiplerini net şekilde anlamasını sağlamaktır.
+
+## Mimarinin Katmanları
+
+1. **Sunum Katmanı**
+   - Flutter tabanlı mobil uygulama
+   - Next.js tabanlı web portalı
+   - Tasarım sistemi: Tailwind + özel bileşen kütüphaneleri
+2. **API & Orta Katman**
+   - NestJS/Node.js tabanlı GraphQL API
+   - Webhook işleyiciler ve real-time abonelikler (GraphQL Subscriptions)
+   - API ağ geçidi, oran sınırlama ve JWT tabanlı oturum yönetimi
+3. **Ajan Orkestrasyonu**
+   - LangChain, OpenAI Functions, özel LLM servisleri
+   - Görev kuyruğu (Redis Streams) ve koordinasyon (Temporal.io)
+   - Ajan görev kayıtları ve telemetri veri tabanı
+4. **Otomasyon & Workflow**
+   - n8n self-hosted örnekleri
+   - GitHub Actions ve Terraform tabanlı altyapı kodu
+   - Hostinger API entegrasyon katmanı
+5. **Veri Katmanı**
+   - PostgreSQL (temel veri)
+   - Redis (önbellek, oturum, kuyruklar)
+   - S3 uyumlu obje depolama (Hostinger veya AWS)
+6. **İzleme & Güvenlik**
+   - Prometheus, Grafana, Loki/Sentry
+   - HashiCorp Vault veya AWS Secrets Manager
+   - WAF, IDS/IPS ve audit log servisleri
+
+## Veri Akışları
+
+1. **Görev Akışı**
+   - Kullanıcı arayüzü -> GraphQL API -> Ajan Orkestratörü -> Workflow -> Otomasyon/Entegrasyon.
+2. **Kod Dağıtım Akışı**
+   - Git push -> GitHub Actions -> Build pipeline -> Hostinger + Mobil dağıtımlar.
+3. **Test Akışı**
+   - Test tetikleyici -> CI pipeline -> Cihaz çiftliği -> Raporlama ajanı -> Portal.
+4. **Geri Bildirim Akışı**
+   - Kullanıcı telemetrisi -> Analitik ajanı -> İçgörü panelleri -> PO bildirimleri.
+
+## Bileşen Detayları
+
+### Kullanıcı Portalı
+- Next.js + Apollo Client
+- SSR/ISR stratejisi ile hızlı yükleme ve SEO uyumu
+- RBAC yetkilendirmesi için GraphQL directive tabanlı kontroller
+
+### Mobil Uygulamalar
+- Flutter modüler yapısı, çoklu hedef (Android, iOS)
+- CI/CD pipeline: Fastlane + Firebase App Distribution + TestFlight
+- Dinamik içerik güncellemeleri için Remote Config
+
+### Ajan Orkestratörü
+- Görev türleri: kod üretimi, test, dağıtım, operasyon, destek
+- Prompt yönetimi ve sürümleme için özel depo
+- Erişim kontrolleri: Her ajan için scoped API anahtarları
+
+### Workflow Motoru
+- n8n node’ları: GitHub, Hostinger, Slack, Jira, Linear, Notion
+- İnsan-in-the-loop (HITL) adımları için manuel onay modülü
+- Zamanlanmış görevler ve olay tetiklemeleri
+
+### Dağıtım Katmanı
+- Terraform ile Hostinger VPS veya Kubernetes cluster yönetimi
+- Docker image registry (GitHub Container Registry)
+- CDN ve edge caching stratejileri
+
+### İzleme & Uyarılar
+- Prometheus exporter’ları (API, ajan, workflow, database)
+- Grafana dashboard setleri (performans, hata oranı, dağıtım metrikleri)
+- Sentry hata izleme ve release health
+
+## Güvenlik Modeli
+
+- **Kimlik & Erişim:** OAuth 2.0, SSO, RBAC, API token’ları.
+- **Veri Koruma:** TLS 1.3, JWT imzalama, veri maskeleme.
+- **Uyumluluk:** SOC2 kontrolleri, audit log retention, gizlilik politikaları.
+- **Olay Müdahalesi:** SIEM entegrasyonu, otomatik uyarılar, olay müdahale runbook’ları.
+
+## Ölçeklenebilirlik Stratejisi
+
+- Kubernetes ile yatay ölçeklenebilir mikro servis mimarisi
+- Otomatik ölçekleme (HPA) ve burst kapasitesi için bulut kaynakları
+- Redis cluster ve PostgreSQL read replica mimarisi
+- Event-driven mimari ile kuyruk tabanlı yük dengeleme
+
+## Yedekleme & Süreklilik
+
+- PostgreSQL için günlük yedekler, point-in-time recovery
+- Obje depolama için sürümleme ve lifecycle politikaları
+- DR planı: Farklı bölgede yedek n8n ve API örnekleri
+
+## Entegrasyon Matrisi
+
+| Servis | Kullanım | Protokol |
+| --- | --- | --- |
+| GitHub | Kod depolama, issues, Actions | REST, GraphQL |
+| Hostinger | Uygulama dağıtımı, DNS yönetimi | REST API |
+| n8n | Otomasyon akışları | REST, Webhook |
+| Firebase | Test dağıtımı, analitik | REST, gRPC |
+| App Store Connect | iOS paket yükleme | REST API |
+| Google Play Developer | Android yayın | REST API |
+| Slack/Teams | Bildirim ve onay | Webhook |
+
+## Açık Sorular
+
+- Ajanların maliyet optimizasyonu için özel LLM barındırma mı kullanılacak?
+- Kullanıcıların kendi ajan modellerini yükleyebilmesi desteklenecek mi?
+- On-premise kurulum ihtiyacı olan müşteriler için nasıl bir dağıtım modeli uygulanacak?
+
+---
+Bu mimari, ürün ihtiyaçlarına göre gelişecektir. Her yeni bileşen eklendiğinde doküman güncellenmelidir.

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -4,8 +4,13 @@
   "description": "App Lab Agent platformu için hafif bir ajan orkestrasyon ve otomasyon sunucusu iskeleti.",
   "main": "src/server.js",
   "scripts": {
-    "start": "node src/server.js",
-    "test": "node --test"
+    "start": "concurrently \"npm:start:backend\" \"npm:start:frontend\"",
+    "start:backend": "node src/server.js",
+    "start:frontend": "cd frontend && npm run dev",
+    "dev": "concurrently \"npm:start:backend\" \"npm:start:frontend\"",
+    "build": "cd frontend && npm run build",
+    "test": "node --test",
+    "lint": "cd frontend && npm run lint"
   },
   "keywords": [
     "agent",
@@ -14,5 +19,23 @@
   ],
   "author": "",
   "license": "MIT",
-  "type": "commonjs"
+  "type": "commonjs",
+  "devDependencies": {
+    "concurrently": "^9.2.1"
+  },
+  "dependencies": {
+    "@prisma/client": "^6.16.2",
+    "@types/bcrypt": "^6.0.0",
+    "@types/cors": "^2.8.19",
+    "@types/express": "^5.0.3",
+    "@types/jsonwebtoken": "^9.0.10",
+    "axios": "^1.12.2",
+    "bcrypt": "^6.0.0",
+    "cors": "^2.8.5",
+    "dotenv": "^17.2.2",
+    "express": "^5.1.0",
+    "jsonwebtoken": "^9.0.2",
+    "pg": "^8.16.3",
+    "prisma": "^6.16.2"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@types/jsonwebtoken": "^9.0.10",
     "axios": "^1.12.2",
     "bcrypt": "^6.0.0",
+    "bcryptjs": "^2.4.3",
     "cors": "^2.8.5",
     "dotenv": "^17.2.2",
     "express": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "applabagent",
+  "version": "1.0.0",
+  "description": "App Lab Agent platformu için hafif bir ajan orkestrasyon ve otomasyon sunucusu iskeleti.",
+  "main": "src/server.js",
+  "scripts": {
+    "start": "node src/server.js",
+    "test": "node --test"
+  },
+  "keywords": [
+    "agent",
+    "automation",
+    "orchestration"
+  ],
+  "author": "",
+  "license": "MIT",
+  "type": "commonjs"
+}

--- a/src/connectors/githubConnector.js
+++ b/src/connectors/githubConnector.js
@@ -1,0 +1,44 @@
+// App Lab Agent - GitHub entegrasyonu için sahte bağlantı ve durum yönetimi modülü.
+
+const store = require('../data/memoryStore');
+
+function connect(token, options = {}) {
+  if (!token) {
+    throw new Error('GitHub bağlantısı için erişim tokenı zorunludur.');
+  }
+
+  const connection = store.setConnection('github', {
+    status: 'connected',
+    metadata: {
+      repo: options.repo || null,
+      organization: options.organization || null
+    }
+  });
+
+  return connection;
+}
+
+function getStatus() {
+  const connection = store.getConnection('github');
+  return connection || { status: 'disconnected' };
+}
+
+function disconnect() {
+  const current = store.getConnection('github');
+  if (!current) {
+    return { status: 'already_disconnected' };
+  }
+
+  store.setConnection('github', {
+    status: 'disconnected',
+    metadata: current.metadata || {}
+  });
+
+  return store.getConnection('github');
+}
+
+module.exports = {
+  connect,
+  getStatus,
+  disconnect
+};

--- a/src/connectors/hostingerConnector.js
+++ b/src/connectors/hostingerConnector.js
@@ -2,15 +2,23 @@
 
 const store = require('../data/memoryStore');
 
-function connect(apiKey, siteId) {
+function connect(apiKey, siteId, domain) {
   if (!apiKey || !siteId) {
     throw new Error('Hostinger bağlantısı için API anahtarı ve site kimliği gereklidir.');
+  }
+
+  const environment = store.getEnvironment();
+  const mappedDomain = (domain || environment.domain || '').trim().toLowerCase();
+
+  if (!mappedDomain) {
+    throw new Error('Hostinger bağlantısı için alan adı yapılandırması gereklidir.');
   }
 
   return store.setConnection('hostinger', {
     status: 'connected',
     metadata: {
-      siteId
+      siteId,
+      domain: mappedDomain
     }
   });
 }
@@ -28,6 +36,7 @@ function triggerDeployment(target = 'staging') {
   return {
     status: 'deployment_requested',
     target,
+    domain: connection.metadata?.domain || null,
     requestedAt: new Date().toISOString()
   };
 }

--- a/src/connectors/hostingerConnector.js
+++ b/src/connectors/hostingerConnector.js
@@ -1,0 +1,39 @@
+// App Lab Agent - Hostinger dağıtım ortamı için temel bağlantı ve yayın simülasyon modülü.
+
+const store = require('../data/memoryStore');
+
+function connect(apiKey, siteId) {
+  if (!apiKey || !siteId) {
+    throw new Error('Hostinger bağlantısı için API anahtarı ve site kimliği gereklidir.');
+  }
+
+  return store.setConnection('hostinger', {
+    status: 'connected',
+    metadata: {
+      siteId
+    }
+  });
+}
+
+function getStatus() {
+  return store.getConnection('hostinger') || { status: 'disconnected' };
+}
+
+function triggerDeployment(target = 'staging') {
+  const connection = store.getConnection('hostinger');
+  if (!connection || connection.status !== 'connected') {
+    throw new Error('Hostinger dağıtımı için önce bağlantı kurulmalıdır.');
+  }
+
+  return {
+    status: 'deployment_requested',
+    target,
+    requestedAt: new Date().toISOString()
+  };
+}
+
+module.exports = {
+  connect,
+  getStatus,
+  triggerDeployment
+};

--- a/src/connectors/hostingerConnector.js
+++ b/src/connectors/hostingerConnector.js
@@ -1,6 +1,8 @@
-// App Lab Agent - Hostinger dağıtım ortamı için temel bağlantı ve yayın simülasyon modülü.
+// App Lab Agent - Hostinger dağıtım ortamı için bağlantı, yayın tetikleme ve altyapı senkronizasyon modülü.
 
 const store = require('../data/memoryStore');
+
+const HOSTINGER_API_BASE_URL = (process.env.HOSTINGER_API_BASE_URL || 'https://developers.hostinger.com').replace(/\/$/, '');
 
 function connect(apiKey, siteId, domain) {
   if (!apiKey || !siteId) {
@@ -18,7 +20,8 @@ function connect(apiKey, siteId, domain) {
     status: 'connected',
     metadata: {
       siteId,
-      domain: mappedDomain
+      domain: mappedDomain,
+      apiKey
     }
   });
 }
@@ -41,8 +44,70 @@ function triggerDeployment(target = 'staging') {
   };
 }
 
+async function listVirtualMachines({ apiKey, page = 1 } = {}) {
+  const connection = store.getConnection('hostinger');
+  const resolvedApiKey = apiKey || connection?.metadata?.apiKey;
+
+  if (!resolvedApiKey) {
+    throw new Error('Hostinger sanal sunucularını sorgulamak için API anahtarı gereklidir.');
+  }
+
+  const url = new URL('/api/vps/v1/virtual-machines', HOSTINGER_API_BASE_URL);
+  if (page) {
+    url.searchParams.set('page', String(page));
+  }
+
+  let response;
+  try {
+    response = await fetch(url.toString(), {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${resolvedApiKey}`,
+        'Content-Type': 'application/json'
+      }
+    });
+  } catch (error) {
+    throw new Error(`Hostinger API isteği başarısız oldu: ${error.message}`);
+  }
+
+  if (!response.ok) {
+    let errorDetails = '';
+    try {
+      errorDetails = await response.text();
+    } catch (error) {
+      errorDetails = error.message;
+    }
+    throw new Error(`Hostinger API hatası (${response.status}): ${errorDetails || response.statusText}`);
+  }
+
+  let payload;
+  try {
+    payload = await response.json();
+  } catch (error) {
+    throw new Error(`Hostinger API yanıtı JSON olarak ayrıştırılamadı: ${error.message}`);
+  }
+
+  const machines = Array.isArray(payload?.data)
+    ? payload.data
+    : payload?.virtual_machines || payload?.items || [];
+
+  const meta = {
+    page,
+    total: payload?.meta?.total ?? payload?.total ?? null,
+    perPage: payload?.meta?.per_page ?? payload?.perPage ?? null
+  };
+
+  return {
+    fetchedAt: new Date().toISOString(),
+    machines,
+    meta,
+    raw: payload
+  };
+}
+
 module.exports = {
   connect,
   getStatus,
-  triggerDeployment
+  triggerDeployment,
+  listVirtualMachines
 };

--- a/src/connectors/n8nConnector.js
+++ b/src/connectors/n8nConnector.js
@@ -1,0 +1,40 @@
+// App Lab Agent - n8n otomasyon akışları için bağlantı ve tetikleme simülasyonu modülü.
+
+const store = require('../data/memoryStore');
+
+function connect(baseUrl, apiKey) {
+  if (!baseUrl || !apiKey) {
+    throw new Error('n8n bağlantısı için temel URL ve API anahtarı gereklidir.');
+  }
+
+  return store.setConnection('n8n', {
+    status: 'connected',
+    metadata: {
+      baseUrl
+    }
+  });
+}
+
+function getStatus() {
+  return store.getConnection('n8n') || { status: 'disconnected' };
+}
+
+function triggerWorkflow(workflowId, input = {}) {
+  const connection = store.getConnection('n8n');
+  if (!connection || connection.status !== 'connected') {
+    throw new Error('n8n akışını tetiklemek için bağlantı kurulmalıdır.');
+  }
+
+  return {
+    status: 'workflow_triggered',
+    workflowId,
+    input,
+    triggeredAt: new Date().toISOString()
+  };
+}
+
+module.exports = {
+  connect,
+  getStatus,
+  triggerWorkflow
+};

--- a/src/controllers/aiController.js
+++ b/src/controllers/aiController.js
@@ -1,0 +1,57 @@
+// App Lab Agent - AI Controller
+const analyticsService = require('../services/analyticsService');
+const loggingService = require('../services/loggingService');
+
+class AIController {
+  async createAgent(req, res) {
+    try {
+      const { name, type, configuration } = req.body;
+      const userId = req.user.id;
+
+      const agent = {
+        id: Date.now(),
+        name,
+        type,
+        configuration: configuration || {},
+        userId,
+        createdAt: new Date().toISOString()
+      };
+
+      res.status(201).json({
+        success: true,
+        agent
+      });
+
+    } catch (error) {
+      loggingService.error('Create AI agent error', { error: error.message });
+      res.status(500).json({
+        success: false,
+        error: 'AI agent oluşturulurken hata oluştu'
+      });
+    }
+  }
+
+  async chat(req, res) {
+    try {
+      const { message } = req.body;
+      
+      const response = {
+        success: true,
+        response: {
+          message: `AI Response to: ${message}`,
+          timestamp: new Date().toISOString()
+        }
+      };
+
+      res.json(response);
+
+    } catch (error) {
+      res.status(500).json({
+        success: false,
+        error: 'AI chat sırasında hata oluştu'
+      });
+    }
+  }
+}
+
+module.exports = new AIController();

--- a/src/controllers/projectController.ts
+++ b/src/controllers/projectController.ts
@@ -1,0 +1,221 @@
+import { Request, Response } from 'express';
+import { prisma } from '../server';
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
+import { ProjectStatus, TaskStatus } from '@prisma/client';
+
+interface AuthRequest extends Request {
+  user?: any;
+}
+
+export const projectController = {
+  // Tüm projeleri getir
+  async getAllProjects(req: AuthRequest, res: Response) {
+    try {
+      const projects = await prisma.project.findMany({
+        where: {
+          creatorId: req.user.id
+        },
+        include: {
+          tasks: true,
+          creator: {
+            select: {
+              id: true,
+              name: true,
+              email: true
+            }
+          }
+        }
+      });
+      res.json(projects);
+    } catch (error) {
+      res.status(500).json({ message: 'Error fetching projects' });
+    }
+  },
+
+  // Tekil proje getir
+  async getProjectById(req: AuthRequest, res: Response) {
+    try {
+      const { id } = req.params;
+      const project = await prisma.project.findUnique({
+        where: { id },
+        include: {
+          tasks: {
+            include: {
+              assignee: {
+                select: {
+                  id: true,
+                  name: true,
+                  email: true
+                }
+              }
+            }
+          },
+          creator: {
+            select: {
+              id: true,
+              name: true,
+              email: true
+            }
+          }
+        }
+      });
+
+      if (!project) {
+        return res.status(404).json({ message: 'Project not found' });
+      }
+
+      if (project.creatorId !== req.user.id) {
+        return res.status(403).json({ message: 'Not authorized' });
+      }
+
+      res.json(project);
+    } catch (error) {
+      res.status(500).json({ message: 'Error fetching project' });
+    }
+  },
+
+  // Yeni proje oluştur
+  async createProject(req: AuthRequest, res: Response) {
+    try {
+      const { name, description, technology, startDate, endDate, repository } = req.body;
+
+      const project = await prisma.project.create({
+        data: {
+          name,
+          description,
+          technology,
+          startDate: startDate ? new Date(startDate) : undefined,
+          endDate: endDate ? new Date(endDate) : undefined,
+          repository,
+          creatorId: req.user.id
+        },
+        include: {
+          creator: {
+            select: {
+              id: true,
+              name: true,
+              email: true
+            }
+          }
+        }
+      });
+
+      res.status(201).json(project);
+    } catch (error) {
+      if (error instanceof PrismaClientKnownRequestError) {
+        return res.status(400).json({ message: 'Invalid project data' });
+      }
+      res.status(500).json({ message: 'Error creating project' });
+    }
+  },
+
+  // Proje güncelle
+  async updateProject(req: AuthRequest, res: Response) {
+    try {
+      const { id } = req.params;
+      const { name, description, status, technology, startDate, endDate, repository } = req.body;
+
+      const project = await prisma.project.findUnique({
+        where: { id }
+      });
+
+      if (!project) {
+        return res.status(404).json({ message: 'Project not found' });
+      }
+
+      if (project.creatorId !== req.user.id) {
+        return res.status(403).json({ message: 'Not authorized' });
+      }
+
+      const updatedProject = await prisma.project.update({
+        where: { id },
+        data: {
+          name,
+          description,
+          status,
+          technology,
+          startDate: startDate ? new Date(startDate) : undefined,
+          endDate: endDate ? new Date(endDate) : undefined,
+          repository
+        },
+        include: {
+          creator: {
+            select: {
+              id: true,
+              name: true,
+              email: true
+            }
+          }
+        }
+      });
+
+      res.json(updatedProject);
+    } catch (error) {
+      if (error instanceof PrismaClientKnownRequestError) {
+        return res.status(400).json({ message: 'Invalid project data' });
+      }
+      res.status(500).json({ message: 'Error updating project' });
+    }
+  },
+
+  // Proje sil
+  async deleteProject(req: AuthRequest, res: Response) {
+    try {
+      const { id } = req.params;
+
+      const project = await prisma.project.findUnique({
+        where: { id }
+      });
+
+      if (!project) {
+        return res.status(404).json({ message: 'Project not found' });
+      }
+
+      if (project.creatorId !== req.user.id) {
+        return res.status(403).json({ message: 'Not authorized' });
+      }
+
+      await prisma.project.delete({
+        where: { id }
+      });
+
+      res.json({ message: 'Project deleted successfully' });
+    } catch (error) {
+      res.status(500).json({ message: 'Error deleting project' });
+    }
+  },
+
+  // Proje istatistikleri
+  async getProjectStats(req: AuthRequest, res: Response) {
+    try {
+      const { id } = req.params;
+
+      const project = await prisma.project.findUnique({
+        where: { id },
+        include: {
+          tasks: true
+        }
+      });
+
+      if (!project) {
+        return res.status(404).json({ message: 'Project not found' });
+      }
+
+      if (project.creatorId !== req.user.id) {
+        return res.status(403).json({ message: 'Not authorized' });
+      }
+
+      const stats = {
+        totalTasks: project.tasks.length,
+        completedTasks: project.tasks.filter((task: { status: string }) => task.status === 'DONE').length,
+        inProgressTasks: project.tasks.filter((task: { status: string }) => task.status === 'IN_PROGRESS').length,
+        todoTasks: project.tasks.filter((task: { status: string }) => task.status === 'TODO').length,
+        reviewTasks: project.tasks.filter((task: { status: string }) => task.status === 'REVIEW').length,
+      };
+
+      res.json(stats);
+    } catch (error) {
+      res.status(500).json({ message: 'Error fetching project statistics' });
+    }
+  }
+};

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -1,0 +1,162 @@
+// App Lab Agent - User Controller
+// Kullanıcı yönetimi için controller
+
+const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
+const notificationService = require('../services/notificationService');
+const analyticsService = require('../services/analyticsService');
+const loggingService = require('../services/loggingService');
+
+class UserController {
+  // Kullanıcı kayıt
+  async register(req, res) {
+    try {
+      const { email, password, firstName, lastName, planType = 'free' } = req.body;
+
+      if (!email || !password || !firstName || !lastName) {
+        return res.status(400).json({
+          success: false,
+          error: 'Email, şifre, ad ve soyad gereklidir'
+        });
+      }
+
+      // Şifreyi hashle
+      const hashedPassword = await bcrypt.hash(password, 12);
+
+      // Mock user creation - gerçek implementasyonda database kullanılır
+      const user = {
+        id: Date.now(),
+        email,
+        firstName,
+        lastName,
+        planType,
+        createdAt: new Date().toISOString()
+      };
+
+      // JWT token oluştur
+      const token = jwt.sign(
+        { userId: user.id, email: user.email },
+        process.env.JWT_SECRET || 'default-secret',
+        { expiresIn: '7d' }
+      );
+
+      res.status(201).json({
+        success: true,
+        user: {
+          id: user.id,
+          email: user.email,
+          firstName: user.firstName,
+          lastName: user.lastName,
+          planType: user.planType
+        },
+        token
+      });
+
+    } catch (error) {
+      loggingService.error('User registration error', { error: error.message });
+      res.status(500).json({
+        success: false,
+        error: 'Kayıt sırasında hata oluştu'
+      });
+    }
+  }
+
+  // Kullanıcı giriş
+  async login(req, res) {
+    try {
+      const { email, password } = req.body;
+
+      if (!email || !password) {
+        return res.status(400).json({
+          success: false,
+          error: 'Email ve şifre gereklidir'
+        });
+      }
+
+      // Mock user - gerçek implementasyonda database'den gelir
+      const user = {
+        id: 1,
+        email,
+        password: await bcrypt.hash('password', 12), // Mock hashed password
+        firstName: 'John',
+        lastName: 'Doe',
+        planType: 'free'
+      };
+
+      // JWT token oluştur
+      const token = jwt.sign(
+        { userId: user.id, email: user.email },
+        process.env.JWT_SECRET || 'default-secret',
+        { expiresIn: '7d' }
+      );
+
+      res.json({
+        success: true,
+        user: {
+          id: user.id,
+          email: user.email,
+          firstName: user.firstName,
+          lastName: user.lastName,
+          planType: user.planType
+        },
+        token
+      });
+
+    } catch (error) {
+      loggingService.error('User login error', { error: error.message });
+      res.status(500).json({
+        success: false,
+        error: 'Giriş sırasında hata oluştu'
+      });
+    }
+  }
+
+  // Kullanıcı profili
+  async getProfile(req, res) {
+    try {
+      const user = req.user;
+
+      res.json({
+        success: true,
+        user
+      });
+
+    } catch (error) {
+      loggingService.error('Get user profile error', { error: error.message });
+      res.status(500).json({
+        success: false,
+        error: 'Profil bilgileri alınırken hata oluştu'
+      });
+    }
+  }
+
+  // Profil güncelle
+  async updateProfile(req, res) {
+    try {
+      const userId = req.user.id;
+      const { firstName, lastName, email } = req.body;
+
+      const updatedUser = {
+        ...req.user,
+        firstName,
+        lastName,
+        email,
+        updatedAt: new Date().toISOString()
+      };
+
+      res.json({
+        success: true,
+        user: updatedUser
+      });
+
+    } catch (error) {
+      loggingService.error('Update profile error', { error: error.message });
+      res.status(500).json({
+        success: false,
+        error: 'Profil güncellenirken hata oluştu'
+      });
+    }
+  }
+}
+
+module.exports = new UserController();

--- a/src/data/memoryStore.js
+++ b/src/data/memoryStore.js
@@ -25,10 +25,20 @@ function listConnections() {
 }
 
 function upsertWorkflow(id, definition) {
+  const existing = memoryState.workflows[id];
+  const timestamp = new Date().toISOString();
+
   memoryState.workflows[id] = {
-    ...definition,
-    updatedAt: new Date().toISOString()
+    id,
+    name: definition?.name || existing?.name || 'Yeni Otomasyon',
+    description: definition?.description || existing?.description || '',
+    tasks: definition?.tasks || existing?.tasks || [],
+    definition: definition?.definition || existing?.definition || {},
+    projectId: definition?.projectId || existing?.projectId || null,
+    createdAt: existing?.createdAt || definition?.createdAt || timestamp,
+    updatedAt: timestamp
   };
+
   return memoryState.workflows[id];
 }
 

--- a/src/data/memoryStore.js
+++ b/src/data/memoryStore.js
@@ -1,11 +1,19 @@
 // App Lab Agent - Basit bellek içi durum deposu; entegrasyon bağlantıları, ajan görevleri,
 // projeler ve otomasyon akışlarını tutar.
 
+const DEFAULT_DOMAIN = 'applabagent.net';
+
 const memoryState = {
   connections: {},
   workflows: {},
   tasks: {},
-  projects: {}
+  projects: {},
+  environment: {
+    domain: DEFAULT_DOMAIN,
+    releaseChannels: {},
+    updatedAt: new Date().toISOString(),
+    createdAt: new Date().toISOString()
+  }
 };
 
 function setConnection(provider, payload) {
@@ -88,11 +96,51 @@ function listProjects() {
   return memoryState.projects;
 }
 
+function getEnvironment() {
+  return memoryState.environment;
+}
+
+function updateEnvironment(updates) {
+  const timestamp = new Date().toISOString();
+  memoryState.environment = {
+    ...memoryState.environment,
+    ...updates,
+    updatedAt: timestamp
+  };
+  if (!memoryState.environment.createdAt) {
+    memoryState.environment.createdAt = timestamp;
+  }
+  return memoryState.environment;
+}
+
+function upsertReleaseChannel(platform, configuration) {
+  const timestamp = new Date().toISOString();
+  const existing = memoryState.environment.releaseChannels[platform];
+
+  memoryState.environment.releaseChannels[platform] = {
+    platform,
+    ...configuration,
+    createdAt: existing?.createdAt || timestamp,
+    updatedAt: timestamp
+  };
+
+  updateEnvironment({});
+
+  return memoryState.environment.releaseChannels[platform];
+}
+
 function reset() {
   memoryState.connections = {};
   memoryState.workflows = {};
   memoryState.tasks = {};
   memoryState.projects = {};
+  const timestamp = new Date().toISOString();
+  memoryState.environment = {
+    domain: DEFAULT_DOMAIN,
+    releaseChannels: {},
+    createdAt: timestamp,
+    updatedAt: timestamp
+  };
 }
 
 module.exports = {
@@ -108,5 +156,8 @@ module.exports = {
   upsertProject,
   getProject,
   listProjects,
+  getEnvironment,
+  updateEnvironment,
+  upsertReleaseChannel,
   reset
 };

--- a/src/data/memoryStore.js
+++ b/src/data/memoryStore.js
@@ -8,6 +8,7 @@ const memoryState = {
   workflows: {},
   tasks: {},
   projects: {},
+  aiAgents: {},
   builds: {},
   releases: {},
   environment: {
@@ -96,6 +97,70 @@ function getProject(id) {
 
 function listProjects() {
   return memoryState.projects;
+}
+
+// Yapay zeka ajan profillerini kaydeden ve güncelleyen yardımcı.
+function upsertAgentProfile(id, agent) {
+  const existing = memoryState.aiAgents[id] || {};
+  const timestamp = new Date().toISOString();
+
+  memoryState.aiAgents[id] = {
+    id,
+    name: agent?.name || existing.name || 'Yeni Ajan',
+    description: agent?.description ?? existing.description ?? '',
+    provider: agent?.provider || existing.provider || 'openai',
+    model: agent?.model || existing.model || 'gpt-4.1',
+    instructions: agent?.instructions || existing.instructions || '',
+    capabilities: Array.isArray(agent?.capabilities)
+      ? agent.capabilities
+      : existing.capabilities || [],
+    metadata: {
+      ...(existing.metadata || {}),
+      ...(agent?.metadata || {})
+    },
+    projectId:
+      Object.prototype.hasOwnProperty.call(agent || {}, 'projectId')
+        ? agent.projectId
+        : Object.prototype.hasOwnProperty.call(existing, 'projectId')
+          ? existing.projectId
+          : null,
+    createdAt: existing.createdAt || agent?.createdAt || timestamp,
+    updatedAt: timestamp
+  };
+
+  return memoryState.aiAgents[id];
+}
+
+// Belirli bir ajan profilini döndüren yardımcı.
+function getAgentProfile(id) {
+  return memoryState.aiAgents[id] || null;
+}
+
+// Ajan profillerinin tamamını döndüren yardımcı.
+function listAgentProfiles() {
+  return memoryState.aiAgents;
+}
+
+// Bir ajan profilini proje ile ilişkilendiren yardımcı.
+function linkAgentToProject(agentId, projectId) {
+  const agent = memoryState.aiAgents[agentId];
+  if (!agent) {
+    return null;
+  }
+
+  agent.projectId = projectId;
+  agent.updatedAt = new Date().toISOString();
+  return agent;
+}
+
+// Bir ajan profilini silen yardımcı.
+function deleteAgentProfile(agentId) {
+  if (!memoryState.aiAgents[agentId]) {
+    return false;
+  }
+
+  delete memoryState.aiAgents[agentId];
+  return true;
 }
 
 function upsertRelease(id, release) {
@@ -282,11 +347,13 @@ function upsertReleaseChannel(platform, configuration) {
   return memoryState.environment.releaseChannels[platform];
 }
 
+// Test senaryoları için bellek durumunu sıfırlayan yardımcı.
 function reset() {
   memoryState.connections = {};
   memoryState.workflows = {};
   memoryState.tasks = {};
   memoryState.projects = {};
+  memoryState.aiAgents = {};
   memoryState.builds = {};
   memoryState.releases = {};
   const timestamp = new Date().toISOString();
@@ -311,6 +378,11 @@ module.exports = {
   upsertProject,
   getProject,
   listProjects,
+  upsertAgentProfile,
+  getAgentProfile,
+  listAgentProfiles,
+  linkAgentToProject,
+  deleteAgentProfile,
   upsertRelease,
   getRelease,
   listReleases,

--- a/src/data/memoryStore.js
+++ b/src/data/memoryStore.js
@@ -11,6 +11,7 @@ const memoryState = {
   aiAgents: {},
   builds: {},
   releases: {},
+  pipelineRuns: {},
   environment: {
     domain: DEFAULT_DOMAIN,
     releaseChannels: {},
@@ -347,6 +348,36 @@ function upsertReleaseChannel(platform, configuration) {
   return memoryState.environment.releaseChannels[platform];
 }
 
+// Pipeline yürütme kayıtlarını saklayan yardımcı.
+function upsertPipelineRun(id, run = {}) {
+  if (!id) {
+    throw new Error('Pipeline kaydı için kimlik gereklidir.');
+  }
+
+  const timestamp = new Date().toISOString();
+  const existing = memoryState.pipelineRuns[id] || {};
+
+  memoryState.pipelineRuns[id] = {
+    id,
+    createdAt: existing?.createdAt || run?.createdAt || timestamp,
+    ...existing,
+    ...run,
+    updatedAt: timestamp
+  };
+
+  return memoryState.pipelineRuns[id];
+}
+
+// Pipeline yürütme kaydını döndüren yardımcı.
+function getPipelineRun(id) {
+  return memoryState.pipelineRuns[id] || null;
+}
+
+// Pipeline yürütmelerinin tamamını listeleyen yardımcı.
+function listPipelineRuns() {
+  return memoryState.pipelineRuns;
+}
+
 // Test senaryoları için bellek durumunu sıfırlayan yardımcı.
 function reset() {
   memoryState.connections = {};
@@ -356,6 +387,7 @@ function reset() {
   memoryState.aiAgents = {};
   memoryState.builds = {};
   memoryState.releases = {};
+  memoryState.pipelineRuns = {};
   const timestamp = new Date().toISOString();
   memoryState.environment = {
     domain: DEFAULT_DOMAIN,
@@ -395,5 +427,8 @@ module.exports = {
   getEnvironment,
   updateEnvironment,
   upsertReleaseChannel,
+  upsertPipelineRun,
+  getPipelineRun,
+  listPipelineRuns,
   reset
 };

--- a/src/data/memoryStore.js
+++ b/src/data/memoryStore.js
@@ -1,0 +1,102 @@
+// App Lab Agent - Basit bellek içi durum deposu; entegrasyon bağlantıları, ajan görevleri,
+// projeler ve otomasyon akışlarını tutar.
+
+const memoryState = {
+  connections: {},
+  workflows: {},
+  tasks: {},
+  projects: {}
+};
+
+function setConnection(provider, payload) {
+  memoryState.connections[provider] = {
+    ...payload,
+    updatedAt: new Date().toISOString()
+  };
+  return memoryState.connections[provider];
+}
+
+function getConnection(provider) {
+  return memoryState.connections[provider] || null;
+}
+
+function listConnections() {
+  return memoryState.connections;
+}
+
+function upsertWorkflow(id, definition) {
+  memoryState.workflows[id] = {
+    ...definition,
+    updatedAt: new Date().toISOString()
+  };
+  return memoryState.workflows[id];
+}
+
+function getWorkflow(id) {
+  return memoryState.workflows[id] || null;
+}
+
+function listWorkflows() {
+  return memoryState.workflows;
+}
+
+function upsertTask(id, task) {
+  memoryState.tasks[id] = {
+    ...task,
+    updatedAt: new Date().toISOString()
+  };
+  return memoryState.tasks[id];
+}
+
+function getTask(id) {
+  return memoryState.tasks[id] || null;
+}
+
+function listTasks() {
+  return memoryState.tasks;
+}
+
+function upsertProject(id, project) {
+  const existing = memoryState.projects[id];
+  const timestamp = new Date().toISOString();
+
+  memoryState.projects[id] = {
+    id,
+    createdAt: existing?.createdAt || project.createdAt || timestamp,
+    ...project,
+    updatedAt: timestamp
+  };
+
+  return memoryState.projects[id];
+}
+
+function getProject(id) {
+  return memoryState.projects[id] || null;
+}
+
+function listProjects() {
+  return memoryState.projects;
+}
+
+function reset() {
+  memoryState.connections = {};
+  memoryState.workflows = {};
+  memoryState.tasks = {};
+  memoryState.projects = {};
+}
+
+module.exports = {
+  setConnection,
+  getConnection,
+  listConnections,
+  upsertWorkflow,
+  getWorkflow,
+  listWorkflows,
+  upsertTask,
+  getTask,
+  listTasks,
+  upsertProject,
+  getProject,
+  listProjects,
+  reset
+};

--- a/src/data/memoryStore.js
+++ b/src/data/memoryStore.js
@@ -8,6 +8,7 @@ const memoryState = {
   workflows: {},
   tasks: {},
   projects: {},
+  builds: {},
   environment: {
     domain: DEFAULT_DOMAIN,
     releaseChannels: {},
@@ -96,6 +97,47 @@ function listProjects() {
   return memoryState.projects;
 }
 
+function upsertBuild(id, build) {
+  const existing = memoryState.builds[id] || {};
+  const timestamp = new Date().toISOString();
+
+  memoryState.builds[id] = {
+    id,
+    createdAt: existing?.createdAt || build?.createdAt || timestamp,
+    history: existing?.history || build?.history || [],
+    ...existing,
+    ...build,
+    updatedAt: timestamp
+  };
+
+  return memoryState.builds[id];
+}
+
+function getBuild(id) {
+  return memoryState.builds[id] || null;
+}
+
+function listBuilds() {
+  return memoryState.builds;
+}
+
+function appendBuildHistory(id, entry) {
+  const build = memoryState.builds[id];
+  if (!build) {
+    return null;
+  }
+
+  const record = {
+    ...entry,
+    timestamp: entry?.timestamp || new Date().toISOString()
+  };
+
+  build.history = [...(build.history || []), record];
+  build.updatedAt = record.timestamp;
+
+  return build;
+}
+
 function getEnvironment() {
   return memoryState.environment;
 }
@@ -134,6 +176,7 @@ function reset() {
   memoryState.workflows = {};
   memoryState.tasks = {};
   memoryState.projects = {};
+  memoryState.builds = {};
   const timestamp = new Date().toISOString();
   memoryState.environment = {
     domain: DEFAULT_DOMAIN,
@@ -156,6 +199,10 @@ module.exports = {
   upsertProject,
   getProject,
   listProjects,
+  upsertBuild,
+  getBuild,
+  listBuilds,
+  appendBuildHistory,
   getEnvironment,
   updateEnvironment,
   upsertReleaseChannel,

--- a/src/data/memoryStore.js
+++ b/src/data/memoryStore.js
@@ -9,6 +9,7 @@ const memoryState = {
   tasks: {},
   projects: {},
   builds: {},
+  releases: {},
   environment: {
     domain: DEFAULT_DOMAIN,
     releaseChannels: {},
@@ -97,6 +98,116 @@ function listProjects() {
   return memoryState.projects;
 }
 
+function upsertRelease(id, release) {
+  const existing = memoryState.releases[id] || {};
+  const timestamp = new Date().toISOString();
+
+  const mergedPlatforms = { ...existing.platforms };
+  if (release?.platforms) {
+    Object.entries(release.platforms).forEach(([platform, configuration]) => {
+      const current = mergedPlatforms[platform] || {};
+      mergedPlatforms[platform] = {
+        platform,
+        status: configuration?.status || current.status || 'pending',
+        buildId:
+          Object.prototype.hasOwnProperty.call(configuration || {}, 'buildId')
+            ? configuration.buildId
+            : Object.prototype.hasOwnProperty.call(current, 'buildId')
+              ? current.buildId
+              : null,
+        storeStatus: configuration?.storeStatus || current.storeStatus || 'not_submitted',
+        storeId: configuration?.storeId || current.storeId || null,
+        submissionNotes: configuration?.submissionNotes || current.submissionNotes || null,
+        lastSubmissionAt: configuration?.lastSubmissionAt || current.lastSubmissionAt || null,
+        metadata: {
+          ...(current.metadata || {}),
+          ...(configuration?.metadata || {})
+        },
+        createdAt: current.createdAt || configuration?.createdAt || timestamp,
+        updatedAt: timestamp
+      };
+    });
+  }
+
+  memoryState.releases[id] = {
+    id,
+    projectId: release?.projectId ?? existing.projectId ?? null,
+    version: release?.version || existing.version || '0.0.1',
+    status: release?.status || existing.status || 'draft',
+    notes: release?.notes ?? existing.notes ?? '',
+    platforms: mergedPlatforms,
+    history: release?.history || existing.history || [],
+    createdAt: existing.createdAt || release?.createdAt || timestamp,
+    updatedAt: timestamp
+  };
+
+  return memoryState.releases[id];
+}
+
+function getRelease(id) {
+  return memoryState.releases[id] || null;
+}
+
+function listReleases() {
+  return memoryState.releases;
+}
+
+function upsertReleasePlatform(id, platform, updates) {
+  const release = memoryState.releases[id];
+  if (!release) {
+    return null;
+  }
+
+  const timestamp = new Date().toISOString();
+  const existing = release.platforms?.[platform] || {};
+
+  const merged = {
+    platform,
+    status: updates?.status || existing.status || 'pending',
+    buildId:
+      Object.prototype.hasOwnProperty.call(updates || {}, 'buildId')
+        ? updates.buildId
+        : Object.prototype.hasOwnProperty.call(existing, 'buildId')
+          ? existing.buildId
+          : null,
+    storeStatus: updates?.storeStatus || existing.storeStatus || 'not_submitted',
+    storeId: updates?.storeId || existing.storeId || null,
+    submissionNotes: updates?.submissionNotes || existing.submissionNotes || null,
+    lastSubmissionAt: updates?.lastSubmissionAt || existing.lastSubmissionAt || null,
+    metadata: {
+      ...(existing.metadata || {}),
+      ...(updates?.metadata || {})
+    },
+    createdAt: existing.createdAt || timestamp,
+    updatedAt: timestamp
+  };
+
+  release.platforms = {
+    ...(release.platforms || {}),
+    [platform]: merged
+  };
+  release.updatedAt = timestamp;
+
+  return merged;
+}
+
+function appendReleaseHistory(id, entry) {
+  const release = memoryState.releases[id];
+  if (!release) {
+    return null;
+  }
+
+  const record = {
+    ...entry,
+    timestamp: entry?.timestamp || new Date().toISOString()
+  };
+
+  release.history = [...(release.history || []), record];
+  release.updatedAt = record.timestamp;
+
+  return release;
+}
+
 function upsertBuild(id, build) {
   const existing = memoryState.builds[id] || {};
   const timestamp = new Date().toISOString();
@@ -177,6 +288,7 @@ function reset() {
   memoryState.tasks = {};
   memoryState.projects = {};
   memoryState.builds = {};
+  memoryState.releases = {};
   const timestamp = new Date().toISOString();
   memoryState.environment = {
     domain: DEFAULT_DOMAIN,
@@ -199,6 +311,11 @@ module.exports = {
   upsertProject,
   getProject,
   listProjects,
+  upsertRelease,
+  getRelease,
+  listReleases,
+  upsertReleasePlatform,
+  appendReleaseHistory,
   upsertBuild,
   getBuild,
   listBuilds,

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -1,0 +1,46 @@
+const jwt = require('jsonwebtoken');
+
+const authenticate = async (req, res, next) => {
+  try {
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      return res.status(401).json({ 
+        success: false,
+        error: 'Token bulunamadı' 
+      });
+    }
+
+    const token = authHeader.split(' ')[1];
+    
+    try {
+      const decoded = jwt.verify(token, process.env.JWT_SECRET || 'default-secret');
+      
+      // Mock user - gerçek implementasyonda database'den gelir
+      req.user = {
+        id: decoded.userId,
+        email: decoded.email,
+        firstName: 'John',
+        lastName: 'Doe',
+        planType: 'free',
+        role: 'user'
+      };
+      
+      next();
+      
+    } catch (jwtError) {
+      return res.status(401).json({ 
+        success: false,
+        error: 'Geçersiz veya süresi dolmuş token' 
+      });
+    }
+    
+  } catch (error) {
+    console.error('Authentication error:', error);
+    res.status(500).json({ 
+      success: false,
+      error: 'Kimlik doğrulama sırasında hata oluştu' 
+    });
+  }
+};
+
+module.exports = { authenticate };

--- a/src/routes/agentProfileRoutes.js
+++ b/src/routes/agentProfileRoutes.js
@@ -1,0 +1,72 @@
+// App Lab Agent - Yapay zeka ajan profili yönetimi için HTTP yönlendiricisi.
+
+const {
+  registerAgentProfile,
+  updateAgentProfile,
+  listAgentProfilesWithFilters,
+  getAgentProfileById,
+  linkProfileToProject,
+  removeAgentProfile
+} = require('../services/aiAgentService');
+
+function route({ method, pathname, body, query }) {
+  if (method === 'POST' && pathname === '/api/agents') {
+    try {
+      const profile = registerAgentProfile(body || {});
+      return { status: 201, data: profile };
+    } catch (error) {
+      return { status: 400, data: { error: error.message } };
+    }
+  }
+
+  if (method === 'GET' && pathname === '/api/agents') {
+    const agents = listAgentProfilesWithFilters(query || {});
+    return { status: 200, data: agents };
+  }
+
+  const agentMatch = pathname.match(/^\/api\/agents\/([^/]+)$/);
+  if (agentMatch) {
+    const agentId = agentMatch[1];
+
+    if (method === 'GET') {
+      const agent = getAgentProfileById(agentId);
+      if (!agent) {
+        return { status: 404, data: { error: 'Ajan profili bulunamadı.' } };
+      }
+      return { status: 200, data: agent };
+    }
+
+    if (method === 'PATCH') {
+      try {
+        const updated = updateAgentProfile(agentId, body || {});
+        return { status: 200, data: updated };
+      } catch (error) {
+        return { status: 404, data: { error: error.message } };
+      }
+    }
+
+    if (method === 'DELETE') {
+      const removed = removeAgentProfile(agentId);
+      if (!removed) {
+        return { status: 404, data: { error: 'Ajan profili bulunamadı.' } };
+      }
+      return { status: 204, data: null };
+    }
+  }
+
+  const linkMatch = pathname.match(/^\/api\/agents\/([^/]+)\/link$/);
+  if (linkMatch && method === 'POST') {
+    const agentId = linkMatch[1];
+    const { projectId } = body || {};
+    try {
+      const agent = linkProfileToProject(agentId, projectId || null);
+      return { status: 200, data: agent };
+    } catch (error) {
+      return { status: 404, data: { error: error.message } };
+    }
+  }
+
+  return null;
+}
+
+module.exports = { route };

--- a/src/routes/aiRoutesNew.js
+++ b/src/routes/aiRoutesNew.js
@@ -1,0 +1,15 @@
+const express = require('express');
+const aiController = require('../controllers/aiController');
+const { authenticate } = require('../middleware/auth');
+
+const router = express.Router();
+
+router.use(authenticate);
+
+// AI Agent yönetimi
+router.post('/agents', aiController.createAgent);
+
+// AI Chat
+router.post('/chat', aiController.chat);
+
+module.exports = router;

--- a/src/routes/buildRoutes.js
+++ b/src/routes/buildRoutes.js
@@ -1,0 +1,53 @@
+// App Lab Agent - Derleme yönetimi uç noktalarını yöneten minimal HTTP yönlendiricisi.
+
+const buildService = require('../services/buildService');
+
+function route({ method, pathname, body, query }) {
+  if (method === 'POST' && pathname === '/api/builds') {
+    try {
+      const build = buildService.createBuild(body || {});
+      return { status: 201, data: build };
+    } catch (error) {
+      return { status: 400, data: { error: error.message } };
+    }
+  }
+
+  if (method === 'POST' && pathname.startsWith('/api/builds/') && pathname.endsWith('/trigger')) {
+    const buildId = pathname.split('/')[3];
+    try {
+      const build = buildService.triggerBuild(buildId, body || {});
+      return { status: 200, data: { message: 'Derleme kuyruğa gönderildi', build } };
+    } catch (error) {
+      return { status: 404, data: { error: error.message } };
+    }
+  }
+
+  if (method === 'PATCH' && pathname.startsWith('/api/builds/') && pathname.endsWith('/status')) {
+    const buildId = pathname.split('/')[3];
+    try {
+      const build = buildService.updateBuildStatus(buildId, body || {});
+      return { status: 200, data: build };
+    } catch (error) {
+      return { status: 404, data: { error: error.message } };
+    }
+  }
+
+  if (method === 'GET' && pathname.startsWith('/api/builds/') && pathname.split('/').length === 4) {
+    const buildId = pathname.split('/')[3];
+    try {
+      const build = buildService.getBuildById(buildId);
+      return { status: 200, data: build };
+    } catch (error) {
+      return { status: 404, data: { error: error.message } };
+    }
+  }
+
+  if (method === 'GET' && pathname === '/api/builds') {
+    const builds = buildService.listBuildsForQuery(query || {});
+    return { status: 200, data: builds };
+  }
+
+  return null;
+}
+
+module.exports = { route };

--- a/src/routes/environmentRoutes.js
+++ b/src/routes/environmentRoutes.js
@@ -1,0 +1,23 @@
+// App Lab Agent - Alan adı ve yayın kanalı yönetimi HTTP uç noktalarını sunan yönlendirici modülü.
+
+const environmentService = require('../services/environmentService');
+
+function route({ method, pathname, body }) {
+  if (method === 'GET' && pathname === '/api/environment') {
+    return { status: 200, data: environmentService.getEnvironmentSnapshot() };
+  }
+
+  if (method === 'POST' && pathname === '/api/environment/domain') {
+    const { domain } = body || {};
+    return { status: 200, data: environmentService.updateDomain(domain) };
+  }
+
+  if (method === 'POST' && pathname === '/api/environment/releases') {
+    const { platform, configuration } = body || {};
+    return { status: 200, data: environmentService.registerReleaseChannel(platform, configuration) };
+  }
+
+  return null;
+}
+
+module.exports = { route };

--- a/src/routes/integrationRoutes.js
+++ b/src/routes/integrationRoutes.js
@@ -4,7 +4,7 @@ const githubConnector = require('../connectors/githubConnector');
 const hostingerConnector = require('../connectors/hostingerConnector');
 const n8nConnector = require('../connectors/n8nConnector');
 
-function route({ method, pathname, body }) {
+async function route({ method, pathname, body, query }) {
   if (method === 'POST' && pathname === '/api/integrations/github/connect') {
     const { token, repo, organization } = body || {};
     const connection = githubConnector.connect(token, { repo, organization });
@@ -31,6 +31,15 @@ function route({ method, pathname, body }) {
   if (method === 'POST' && pathname === '/api/integrations/hostinger/deploy') {
     const { target } = body || {};
     return { status: 200, data: hostingerConnector.triggerDeployment(target) };
+  }
+
+  if (method === 'GET' && pathname === '/api/integrations/hostinger/virtual-machines') {
+    const page = query?.page ? Number.parseInt(query.page, 10) : undefined;
+    const result = await hostingerConnector.listVirtualMachines({
+      apiKey: query?.apiKey,
+      page: Number.isFinite(page) && page > 0 ? page : 1
+    });
+    return { status: 200, data: result };
   }
 
   if (method === 'POST' && pathname === '/api/integrations/n8n/connect') {

--- a/src/routes/integrationRoutes.js
+++ b/src/routes/integrationRoutes.js
@@ -20,8 +20,8 @@ function route({ method, pathname, body }) {
   }
 
   if (method === 'POST' && pathname === '/api/integrations/hostinger/connect') {
-    const { apiKey, siteId } = body || {};
-    return { status: 200, data: hostingerConnector.connect(apiKey, siteId) };
+    const { apiKey, siteId, domain } = body || {};
+    return { status: 200, data: hostingerConnector.connect(apiKey, siteId, domain) };
   }
 
   if (method === 'GET' && pathname === '/api/integrations/hostinger/status') {

--- a/src/routes/integrationRoutes.js
+++ b/src/routes/integrationRoutes.js
@@ -1,0 +1,53 @@
+// App Lab Agent - GitHub, Hostinger ve n8n entegrasyon uç noktalarını haritalayan yönlendirici modül.
+
+const githubConnector = require('../connectors/githubConnector');
+const hostingerConnector = require('../connectors/hostingerConnector');
+const n8nConnector = require('../connectors/n8nConnector');
+
+function route({ method, pathname, body }) {
+  if (method === 'POST' && pathname === '/api/integrations/github/connect') {
+    const { token, repo, organization } = body || {};
+    const connection = githubConnector.connect(token, { repo, organization });
+    return { status: 200, data: connection };
+  }
+
+  if (method === 'GET' && pathname === '/api/integrations/github/status') {
+    return { status: 200, data: githubConnector.getStatus() };
+  }
+
+  if (method === 'POST' && pathname === '/api/integrations/github/disconnect') {
+    return { status: 200, data: githubConnector.disconnect() };
+  }
+
+  if (method === 'POST' && pathname === '/api/integrations/hostinger/connect') {
+    const { apiKey, siteId } = body || {};
+    return { status: 200, data: hostingerConnector.connect(apiKey, siteId) };
+  }
+
+  if (method === 'GET' && pathname === '/api/integrations/hostinger/status') {
+    return { status: 200, data: hostingerConnector.getStatus() };
+  }
+
+  if (method === 'POST' && pathname === '/api/integrations/hostinger/deploy') {
+    const { target } = body || {};
+    return { status: 200, data: hostingerConnector.triggerDeployment(target) };
+  }
+
+  if (method === 'POST' && pathname === '/api/integrations/n8n/connect') {
+    const { baseUrl, apiKey } = body || {};
+    return { status: 200, data: n8nConnector.connect(baseUrl, apiKey) };
+  }
+
+  if (method === 'GET' && pathname === '/api/integrations/n8n/status') {
+    return { status: 200, data: n8nConnector.getStatus() };
+  }
+
+  if (method === 'POST' && pathname === '/api/integrations/n8n/trigger') {
+    const { workflowId, input } = body || {};
+    return { status: 200, data: n8nConnector.triggerWorkflow(workflowId, input) };
+  }
+
+  return null;
+}
+
+module.exports = { route };

--- a/src/routes/pipelineRoutes.js
+++ b/src/routes/pipelineRoutes.js
@@ -1,0 +1,32 @@
+// App Lab Agent - Pipeline planlama ve yürütme uç noktalarını yöneten HTTP yönlendirici modülü.
+
+const pipelineService = require('../services/pipelineService');
+
+function route({ method, pathname, body, query }) {
+  if (method === 'POST' && pathname === '/api/pipeline/plan') {
+    const result = pipelineService.planDelivery(body || {});
+    return { status: 200, data: result };
+  }
+
+  if (method === 'POST' && pathname === '/api/pipeline/execute') {
+    const result = pipelineService.executeDelivery(body || {});
+    return { status: 200, data: result };
+  }
+
+  if (method === 'GET' && pathname === '/api/pipeline/runs') {
+    return { status: 200, data: pipelineService.listPipelineRuns() };
+  }
+
+  if (method === 'GET' && pathname === '/api/pipeline/runs/detail') {
+    const runId = query?.id;
+    if (!runId) {
+      return { status: 400, data: { error: 'Pipeline kimliği zorunludur.' } };
+    }
+    const result = pipelineService.getPipelineRunDetail(runId);
+    return { status: 200, data: result };
+  }
+
+  return null;
+}
+
+module.exports = { route };

--- a/src/routes/projectRoutes.js
+++ b/src/routes/projectRoutes.js
@@ -1,0 +1,41 @@
+// App Lab Agent - Proje kayıtları, entegrasyon bağlantıları ve görev eşlemeleri için API yönlendiricisi.
+
+const projectService = require('../services/projectService');
+
+function route({ method, pathname, body }) {
+  if (method === 'POST' && pathname === '/api/projects') {
+    const { id, name, description } = body || {};
+    const project = projectService.createProject(id, { name, description });
+    return { status: 201, data: project };
+  }
+
+  if (method === 'GET' && pathname === '/api/projects') {
+    return { status: 200, data: projectService.listProjectSummaries() };
+  }
+
+  const projectMatch = pathname.match(/^\/api\/projects\/([^/]+)$/);
+  if (projectMatch && method === 'GET') {
+    const projectId = projectMatch[1];
+    return { status: 200, data: projectService.getProject(projectId) };
+  }
+
+  const integrationMatch = pathname.match(/^\/api\/projects\/([^/]+)\/integrations$/);
+  if (integrationMatch && method === 'POST') {
+    const projectId = integrationMatch[1];
+    const { provider, details } = body || {};
+    const project = projectService.linkIntegration(projectId, provider, details);
+    return { status: 200, data: project };
+  }
+
+  const taskMatch = pathname.match(/^\/api\/projects\/([^/]+)\/tasks$/);
+  if (taskMatch && method === 'POST') {
+    const projectId = taskMatch[1];
+    const { taskId, runPolicy } = body || {};
+    const project = projectService.registerTaskMapping(projectId, taskId, { runPolicy });
+    return { status: 200, data: project };
+  }
+
+  return null;
+}
+
+module.exports = { route };

--- a/src/routes/releaseRoutes.js
+++ b/src/routes/releaseRoutes.js
@@ -1,0 +1,54 @@
+// App Lab Agent - Sürüm ve dağıtım akışlarını yöneten HTTP yönlendiricisi; platform durumlarını API üzerinden günceller.
+
+const releaseService = require('../services/releaseService');
+
+function route({ method, pathname, body, query }) {
+  if (method === 'POST' && pathname === '/api/releases') {
+    const release = releaseService.createRelease(body || {});
+    return { status: 201, data: release };
+  }
+
+  if (method === 'GET' && pathname === '/api/releases') {
+    const releases = releaseService.listReleaseSummaries({ projectId: query?.projectId });
+    return { status: 200, data: releases };
+  }
+
+  const detailMatch = pathname.match(/^\/api\/releases\/([^/]+)$/);
+  if (detailMatch && method === 'GET') {
+    const releaseId = detailMatch[1];
+    return { status: 200, data: releaseService.getReleaseDetail(releaseId) };
+  }
+
+  const promoteMatch = pathname.match(/^\/api\/releases\/([^/]+)\/promote$/);
+  if (promoteMatch && method === 'POST') {
+    const releaseId = promoteMatch[1];
+    const { status, actor, message } = body || {};
+    const updated = releaseService.promoteRelease(releaseId, status, actor, message);
+    return { status: 200, data: updated };
+  }
+
+  const platformMatch = pathname.match(/^\/api\/releases\/([^/]+)\/platforms$/);
+  if (platformMatch && method === 'POST') {
+    const releaseId = platformMatch[1];
+    const { platform, buildId, updates = {}, actor } = body || {};
+
+    if (buildId) {
+      const platformState = releaseService.assignPlatformBuild(releaseId, platform, buildId, actor);
+      return { status: 200, data: platformState };
+    }
+
+    const platformState = releaseService.updatePlatformStatus(releaseId, platform, updates, actor);
+    return { status: 200, data: platformState };
+  }
+
+  const milestoneMatch = pathname.match(/^\/api\/releases\/([^/]+)\/timeline$/);
+  if (milestoneMatch && method === 'POST') {
+    const releaseId = milestoneMatch[1];
+    const updated = releaseService.recordMilestone(releaseId, body || {});
+    return { status: 200, data: updated };
+  }
+
+  return null;
+}
+
+module.exports = { route };

--- a/src/routes/statusRoutes.js
+++ b/src/routes/statusRoutes.js
@@ -1,0 +1,21 @@
+// App Lab Agent - Platform durum özetlerini ve son etkinlik listesini sunan HTTP yönlendiricisi.
+
+const statusService = require('../services/statusService');
+
+async function route({ method, pathname, query }) {
+  if (method === 'GET' && pathname === '/api/status/summary') {
+    const summary = statusService.buildPlatformSummary();
+    return { status: 200, data: summary };
+  }
+
+  if (method === 'GET' && pathname === '/api/status/recent-activity') {
+    const limit = query?.limit ? Number.parseInt(query.limit, 10) : undefined;
+    const normalized = Number.isFinite(limit) && limit > 0 ? limit : undefined;
+    const activity = statusService.getRecentActivity(normalized);
+    return { status: 200, data: activity };
+  }
+
+  return null;
+}
+
+module.exports = { route };

--- a/src/routes/taskRoutes.js
+++ b/src/routes/taskRoutes.js
@@ -1,0 +1,47 @@
+// App Lab Agent - Ajan görevleri, kuyruk işlemleri ve otomasyon tetikleyicileri için API yönlendiricisi.
+
+const orchestrator = require('../services/agentOrchestrator');
+const automationRunner = require('../services/automationRunner');
+
+function route({ method, pathname, body }) {
+  if (method === 'POST' && pathname === '/api/tasks') {
+    const { id, definition } = body || {};
+    const task = orchestrator.registerTask(id, definition);
+    return { status: 201, data: task };
+  }
+
+  if (method === 'GET' && pathname === '/api/tasks') {
+    const tasks = orchestrator.listAllTasks();
+    return { status: 200, data: tasks };
+  }
+
+  const dispatchMatch = pathname.match(/^\/api\/tasks\/([^/]+)\/dispatch$/);
+  if (dispatchMatch && method === 'POST') {
+    const taskId = dispatchMatch[1];
+    const { context } = body || {};
+    const task = orchestrator.dispatchTask(taskId, context);
+    return { status: 200, data: task };
+  }
+
+  const statusMatch = pathname.match(/^\/api\/tasks\/([^/]+)$/);
+  if (statusMatch && method === 'GET') {
+    const taskId = statusMatch[1];
+    return { status: 200, data: orchestrator.getTaskStatus(taskId) };
+  }
+
+  if (method === 'POST' && pathname === '/api/queue/process') {
+    const result = automationRunner.processNext();
+    if (!result) {
+      return { status: 204, data: null };
+    }
+    return { status: 200, data: result };
+  }
+
+  if (method === 'GET' && pathname === '/api/queue/pending') {
+    return { status: 200, data: automationRunner.pendingJobs() };
+  }
+
+  return null;
+}
+
+module.exports = { route };

--- a/src/routes/userRoutesNew.js
+++ b/src/routes/userRoutesNew.js
@@ -1,0 +1,22 @@
+const express = require('express');
+const userController = require('../controllers/userController');
+const { authenticate } = require('../middleware/auth');
+
+const router = express.Router();
+
+// Kullanıcı kaydı
+router.post('/register', userController.register);
+
+// Kullanıcı girişi
+router.post('/login', userController.login);
+
+// Korumalı route'lar
+router.use(authenticate);
+
+// Kullanıcı profili
+router.get('/profile', userController.getProfile);
+
+// Profil güncelle
+router.put('/profile', userController.updateProfile);
+
+module.exports = router;

--- a/src/routes/workflowRoutes.js
+++ b/src/routes/workflowRoutes.js
@@ -1,0 +1,65 @@
+// App Lab Agent - Otomasyon iş akışı uç noktalarını yöneten yönlendirici katmanı.
+
+const workflowService = require('../services/workflowService');
+
+function route({ method, pathname, body }) {
+  if (method === 'GET' && pathname === '/api/workflows') {
+    return {
+      status: 200,
+      data: workflowService.listAllWorkflows()
+    };
+  }
+
+  if (method === 'POST' && pathname === '/api/workflows') {
+    try {
+      const workflow = workflowService.registerWorkflow(body?.id, body || {});
+      return {
+        status: 201,
+        data: workflow
+      };
+    } catch (error) {
+      return {
+        status: 400,
+        data: { error: error.message }
+      };
+    }
+  }
+
+  const attachMatch = pathname.match(/^\/api\/workflows\/([^/]+)\/attach-task$/);
+  if (method === 'POST' && attachMatch) {
+    try {
+      const workflowId = attachMatch[1];
+      const result = workflowService.attachTask(workflowId, body?.taskId);
+      return {
+        status: 200,
+        data: result
+      };
+    } catch (error) {
+      return {
+        status: 400,
+        data: { error: error.message }
+      };
+    }
+  }
+
+  const triggerMatch = pathname.match(/^\/api\/workflows\/([^/]+)\/trigger$/);
+  if (method === 'POST' && triggerMatch) {
+    try {
+      const workflowId = triggerMatch[1];
+      const result = workflowService.trigger(workflowId, body?.context || {});
+      return {
+        status: 202,
+        data: result
+      };
+    } catch (error) {
+      return {
+        status: 400,
+        data: { error: error.message }
+      };
+    }
+  }
+
+  return null;
+}
+
+module.exports = { route };

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,105 @@
+// App Lab Agent - HTTP sunucusu; entegrasyon ve ajan yönetimi uç noktalarını yöneten ana giriş noktası.
+
+const http = require('http');
+const { URL } = require('url');
+const integrationRoutes = require('./routes/integrationRoutes');
+const taskRoutes = require('./routes/taskRoutes');
+const projectRoutes = require('./routes/projectRoutes');
+
+const PORT = process.env.PORT || 4000;
+
+function sendJson(res, statusCode, data) {
+  res.writeHead(statusCode, {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type'
+  });
+
+  if (data === null || typeof data === 'undefined') {
+    return res.end();
+  }
+
+  res.end(JSON.stringify(data));
+}
+
+function parseBody(req) {
+  return new Promise((resolve, reject) => {
+    let body = '';
+    req.on('data', (chunk) => {
+      body += chunk;
+      if (body.length > 1e6) {
+        req.destroy();
+        reject(new Error('İstek gövdesi çok büyük.'));
+      }
+    });
+
+    req.on('end', () => {
+      if (!body) {
+        resolve(null);
+        return;
+      }
+
+      try {
+        resolve(JSON.parse(body));
+      } catch (error) {
+        reject(new Error('Geçersiz JSON gövdesi.'));
+      }
+    });
+
+    req.on('error', (error) => reject(error));
+  });
+}
+
+const server = http.createServer(async (req, res) => {
+  if (req.method === 'OPTIONS') {
+    return sendJson(res, 204, null);
+  }
+
+  const url = new URL(req.url, `http://${req.headers.host || 'localhost'}`);
+
+  if (url.pathname === '/health') {
+    return sendJson(res, 200, { status: 'ok', timestamp: new Date().toISOString() });
+  }
+
+  let body = null;
+  if (['POST', 'PUT', 'PATCH'].includes(req.method)) {
+    try {
+      body = await parseBody(req);
+    } catch (error) {
+      return sendJson(res, 400, { error: error.message });
+    }
+  }
+
+  const payload = {
+    method: req.method,
+    pathname: url.pathname,
+    body
+  };
+
+  try {
+    const handlers = [integrationRoutes.route, taskRoutes.route, projectRoutes.route];
+    for (const handler of handlers) {
+      const result = handler(payload);
+      if (result) {
+        return sendJson(res, result.status, result.data);
+      }
+    }
+
+    return sendJson(res, 404, { error: 'Kaynak bulunamadı.' });
+  } catch (error) {
+    return sendJson(res, 500, {
+      error: 'Beklenmeyen sunucu hatası meydana geldi.',
+      details: error.message
+    });
+  }
+});
+
+if (require.main === module) {
+  server.listen(PORT, () => {
+    // eslint-disable-next-line no-console
+    console.log(`App Lab Agent sunucusu ${PORT} portunda çalışıyor.`);
+  });
+}
+
+module.exports = server;

--- a/src/server.js
+++ b/src/server.js
@@ -7,6 +7,7 @@ const taskRoutes = require('./routes/taskRoutes');
 const projectRoutes = require('./routes/projectRoutes');
 const workflowRoutes = require('./routes/workflowRoutes');
 const environmentRoutes = require('./routes/environmentRoutes');
+const buildRoutes = require('./routes/buildRoutes');
 
 const PORT = process.env.PORT || 4000;
 
@@ -76,7 +77,8 @@ const server = http.createServer(async (req, res) => {
   const payload = {
     method: req.method,
     pathname: url.pathname,
-    body
+    body,
+    query: Object.fromEntries(url.searchParams.entries())
   };
 
   try {
@@ -85,7 +87,8 @@ const server = http.createServer(async (req, res) => {
       taskRoutes.route,
       projectRoutes.route,
       workflowRoutes.route,
-      environmentRoutes.route
+      environmentRoutes.route,
+      buildRoutes.route
     ];
     for (const handler of handlers) {
       const result = handler(payload);

--- a/src/server.js
+++ b/src/server.js
@@ -10,6 +10,7 @@ const workflowRoutes = require('./routes/workflowRoutes');
 const environmentRoutes = require('./routes/environmentRoutes');
 const buildRoutes = require('./routes/buildRoutes');
 const releaseRoutes = require('./routes/releaseRoutes');
+const pipelineRoutes = require('./routes/pipelineRoutes');
 
 const PORT = process.env.PORT || 4000;
 
@@ -92,7 +93,8 @@ const server = http.createServer(async (req, res) => {
       workflowRoutes.route,
       environmentRoutes.route,
       buildRoutes.route,
-      releaseRoutes.route
+      releaseRoutes.route,
+      pipelineRoutes.route
     ];
     for (const handler of handlers) {
       const result = handler(payload);

--- a/src/server.js
+++ b/src/server.js
@@ -5,6 +5,7 @@ const { URL } = require('url');
 const integrationRoutes = require('./routes/integrationRoutes');
 const taskRoutes = require('./routes/taskRoutes');
 const projectRoutes = require('./routes/projectRoutes');
+const agentProfileRoutes = require('./routes/agentProfileRoutes');
 const workflowRoutes = require('./routes/workflowRoutes');
 const environmentRoutes = require('./routes/environmentRoutes');
 const buildRoutes = require('./routes/buildRoutes');
@@ -85,6 +86,7 @@ const server = http.createServer(async (req, res) => {
   try {
     const handlers = [
       integrationRoutes.route,
+      agentProfileRoutes.route,
       taskRoutes.route,
       projectRoutes.route,
       workflowRoutes.route,

--- a/src/server.js
+++ b/src/server.js
@@ -6,6 +6,7 @@ const integrationRoutes = require('./routes/integrationRoutes');
 const taskRoutes = require('./routes/taskRoutes');
 const projectRoutes = require('./routes/projectRoutes');
 const workflowRoutes = require('./routes/workflowRoutes');
+const environmentRoutes = require('./routes/environmentRoutes');
 
 const PORT = process.env.PORT || 4000;
 
@@ -83,7 +84,8 @@ const server = http.createServer(async (req, res) => {
       integrationRoutes.route,
       taskRoutes.route,
       projectRoutes.route,
-      workflowRoutes.route
+      workflowRoutes.route,
+      environmentRoutes.route
     ];
     for (const handler of handlers) {
       const result = handler(payload);

--- a/src/server.js
+++ b/src/server.js
@@ -97,7 +97,7 @@ const server = http.createServer(async (req, res) => {
       pipelineRoutes.route
     ];
     for (const handler of handlers) {
-      const result = handler(payload);
+      const result = await handler(payload);
       if (result) {
         return sendJson(res, result.status, result.data);
       }

--- a/src/server.js
+++ b/src/server.js
@@ -5,6 +5,7 @@ const { URL } = require('url');
 const integrationRoutes = require('./routes/integrationRoutes');
 const taskRoutes = require('./routes/taskRoutes');
 const projectRoutes = require('./routes/projectRoutes');
+const workflowRoutes = require('./routes/workflowRoutes');
 
 const PORT = process.env.PORT || 4000;
 
@@ -78,7 +79,12 @@ const server = http.createServer(async (req, res) => {
   };
 
   try {
-    const handlers = [integrationRoutes.route, taskRoutes.route, projectRoutes.route];
+    const handlers = [
+      integrationRoutes.route,
+      taskRoutes.route,
+      projectRoutes.route,
+      workflowRoutes.route
+    ];
     for (const handler of handlers) {
       const result = handler(payload);
       if (result) {

--- a/src/server.js
+++ b/src/server.js
@@ -11,6 +11,7 @@ const environmentRoutes = require('./routes/environmentRoutes');
 const buildRoutes = require('./routes/buildRoutes');
 const releaseRoutes = require('./routes/releaseRoutes');
 const pipelineRoutes = require('./routes/pipelineRoutes');
+const statusRoutes = require('./routes/statusRoutes');
 
 const PORT = process.env.PORT || 4000;
 
@@ -94,7 +95,8 @@ const server = http.createServer(async (req, res) => {
       environmentRoutes.route,
       buildRoutes.route,
       releaseRoutes.route,
-      pipelineRoutes.route
+      pipelineRoutes.route,
+      statusRoutes.route
     ];
     for (const handler of handlers) {
       const result = await handler(payload);

--- a/src/server.js
+++ b/src/server.js
@@ -8,6 +8,7 @@ const projectRoutes = require('./routes/projectRoutes');
 const workflowRoutes = require('./routes/workflowRoutes');
 const environmentRoutes = require('./routes/environmentRoutes');
 const buildRoutes = require('./routes/buildRoutes');
+const releaseRoutes = require('./routes/releaseRoutes');
 
 const PORT = process.env.PORT || 4000;
 
@@ -88,7 +89,8 @@ const server = http.createServer(async (req, res) => {
       projectRoutes.route,
       workflowRoutes.route,
       environmentRoutes.route,
-      buildRoutes.route
+      buildRoutes.route,
+      releaseRoutes.route
     ];
     for (const handler of handlers) {
       const result = handler(payload);

--- a/src/server.js
+++ b/src/server.js
@@ -117,9 +117,8 @@ const server = http.createServer(async (req, res) => {
 const express = require('express');
 const cors = require('cors');
 const dotenv = require('dotenv');
-const { createTables } = require('./data/database.js');
-const userRoutes = require('./routes/userRoutes.js');
-const aiRoutes = require('./routes/aiRoutes.js');
+const userRoutes = require('./routes/userRoutesNew.js');
+const aiRoutes = require('./routes/aiRoutesNew.js');
 
 if (require.main === module) {
   dotenv.config();
@@ -128,8 +127,14 @@ if (require.main === module) {
   app.use(cors());
   app.use(express.json());
 
-  // Veritabanı tablolarını oluştur
-  createTables().catch(console.error);
+  // Health check
+  app.get('/health', (req, res) => {
+    res.json({ 
+      status: 'ok', 
+      timestamp: new Date().toISOString(),
+      version: '1.0.0'
+    });
+  });
 
   // Routes
   app.use('/api/user', userRoutes);
@@ -138,17 +143,22 @@ if (require.main === module) {
   // Error handler
   app.use((err, req, res, next) => {
     console.error(err.stack);
-    res.status(500).json({ error: 'Something went wrong!' });
+    res.status(500).json({ 
+      success: false,
+      error: 'Something went wrong!',
+      timestamp: new Date().toISOString()
+    });
   });
 
   const EXPRESS_PORT = process.env.PORT || 3000;
   app.listen(EXPRESS_PORT, () => {
-    console.log(`AppLab Agent platformu ${EXPRESS_PORT} portunda çalışıyor...`);
+    console.log(`🚀 AppLab Agent platformu ${EXPRESS_PORT} portunda çalışıyor...`);
+    console.log(`📊 Dashboard: http://localhost:${EXPRESS_PORT}`);
+    console.log(`📚 API Health: http://localhost:${EXPRESS_PORT}/health`);
   });
 
   server.listen(PORT, () => {
-    // eslint-disable-next-line no-console
-    console.log(`HTTP sunucusu ${PORT} portunda çalışıyor...`);
+    console.log(`🔧 HTTP sunucusu ${PORT} portunda çalışıyor...`);
   });
 }
 

--- a/src/server.js
+++ b/src/server.js
@@ -114,10 +114,41 @@ const server = http.createServer(async (req, res) => {
   }
 });
 
+const express = require('express');
+const cors = require('cors');
+const dotenv = require('dotenv');
+const { createTables } = require('./data/database.js');
+const userRoutes = require('./routes/userRoutes.js');
+const aiRoutes = require('./routes/aiRoutes.js');
+
 if (require.main === module) {
+  dotenv.config();
+
+  const app = express();
+  app.use(cors());
+  app.use(express.json());
+
+  // Veritabanı tablolarını oluştur
+  createTables().catch(console.error);
+
+  // Routes
+  app.use('/api/user', userRoutes);
+  app.use('/api/ai', aiRoutes);
+
+  // Error handler
+  app.use((err, req, res, next) => {
+    console.error(err.stack);
+    res.status(500).json({ error: 'Something went wrong!' });
+  });
+
+  const EXPRESS_PORT = process.env.PORT || 3000;
+  app.listen(EXPRESS_PORT, () => {
+    console.log(`AppLab Agent platformu ${EXPRESS_PORT} portunda çalışıyor...`);
+  });
+
   server.listen(PORT, () => {
     // eslint-disable-next-line no-console
-    console.log(`App Lab Agent sunucusu ${PORT} portunda çalışıyor.`);
+    console.log(`HTTP sunucusu ${PORT} portunda çalışıyor...`);
   });
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,110 @@
+import express from 'express';import express from 'express';
+
+import cors from 'cors';import cors from 'cors';
+
+import { PrismaClient } from '@prisma/client';import { PrismaClient } from '@prisma/client';
+
+import dotenv from 'dotenv';import dotenv from 'dotenv';
+
+import authRoutes from './routes/authRoutes';import authRoutes from './routes/authRoutes';
+
+import projectRoutes from './routes/projectRoutes';import projectRoutes from './routes/projectRoutes';
+
+import taskRoutes from './routes/taskRoutes';import taskRoutes from './routes/taskRoutes';
+
+import userRoutes from './routes/userRoutes';import userRoutes from './routes/userRoutes';
+
+import { errorHandler } from './middleware/errorHandler';import { errorHandler } from './middleware/errorHandler';
+
+import { authenticate } from './middleware/authenticate';
+
+dotenv.config();
+
+dotenv.config();
+
+const app = express();
+
+export const prisma = new PrismaClient();const app = express();
+
+export const prisma = new PrismaClient();
+
+// Middleware
+
+app.use(cors());// Middleware
+
+app.use(express.json());app.use(cors());
+
+app.use(express.urlencoded({ extended: true }));app.use(express.json());
+
+app.use(express.urlencoded({ extended: true }));
+
+// Health check
+
+app.get('/health', (req, res) => {// Routes
+
+  res.json({ status: 'ok', timestamp: new Date().toISOString() });app.use('/api/auth', authRoutes);
+
+});app.use('/api/projects', authenticate, projectRoutes);
+
+app.use('/api/tasks', authenticate, taskRoutes);
+
+// Routesapp.use('/api/users', authenticate, userRoutes);
+
+app.use('/api/auth', authRoutes);
+
+app.use('/api/projects', projectRoutes);// Error handling
+
+app.use('/api/tasks', taskRoutes);app.use(errorHandler);
+
+app.use('/api/users', userRoutes);
+
+const PORT = process.env.PORT || 3001;
+
+// Error handling
+
+app.use(errorHandler);async function startServer() {
+
+  try {
+
+const PORT = process.env.PORT || 3001;    await prisma.$connect();
+
+    console.log('🎯 Connected to database');
+
+async function startServer() {    
+
+  try {    app.listen(PORT, () => {
+
+    await prisma.$connect();      console.log(`🚀 Server running on port ${PORT}`);
+
+    console.log('📦 Connected to database');    });
+
+      } catch (error) {
+
+    app.listen(PORT, () => {    console.error('❌ Error starting server:', error);
+
+      console.log(`🚀 Server running on port ${PORT}`);    process.exit(1);
+
+    });  }
+
+  } catch (error) {}
+
+    console.error('❌ Error starting server:', error);
+
+    process.exit(1);startServer();
+  }
+}
+
+// Handle graceful shutdown
+process.on('SIGTERM', async () => {
+  console.log('SIGTERM received. Shutting down gracefully...');
+  await prisma.$disconnect();
+  process.exit(0);
+});
+
+process.on('SIGINT', async () => {
+  console.log('SIGINT received. Shutting down gracefully...');
+  await prisma.$disconnect();
+  process.exit(0);
+});
+
+startServer();

--- a/src/services/agentOrchestrator.js
+++ b/src/services/agentOrchestrator.js
@@ -1,0 +1,53 @@
+// App Lab Agent - Yapay zeka ajan görevlerini planlayan ve otomasyon motoruna ileten orkestrasyon hizmeti.
+
+const { upsertTask, getTask, listTasks } = require('../data/memoryStore');
+const automationRunner = require('./automationRunner');
+
+function registerTask(taskId, definition) {
+  if (!taskId) {
+    throw new Error('Ajan görevi kaydı için kimlik gereklidir.');
+  }
+
+  const task = upsertTask(taskId, {
+    status: 'registered',
+    definition
+  });
+
+  return task;
+}
+
+function dispatchTask(taskId, context = {}) {
+  const task = getTask(taskId);
+  if (!task) {
+    throw new Error(`Görev bulunamadı: ${taskId}`);
+  }
+
+  const scheduled = upsertTask(taskId, {
+    ...task,
+    status: 'queued',
+    lastContext: context
+  });
+
+  automationRunner.enqueue({
+    taskId,
+    definition: scheduled.definition,
+    context
+  });
+
+  return scheduled;
+}
+
+function getTaskStatus(taskId) {
+  return getTask(taskId);
+}
+
+function listAllTasks() {
+  return listTasks();
+}
+
+module.exports = {
+  registerTask,
+  dispatchTask,
+  getTaskStatus,
+  listAllTasks
+};

--- a/src/services/aiAgentService.js
+++ b/src/services/aiAgentService.js
@@ -1,0 +1,68 @@
+// App Lab Agent - Yapay zeka ajan profillerini yöneten servis katmanı.
+
+const {
+  upsertAgentProfile,
+  getAgentProfile,
+  listAgentProfiles,
+  linkAgentToProject,
+  deleteAgentProfile
+} = require('../data/memoryStore');
+
+// Yeni bir ajan profilini kaydeden yardımcı.
+function registerAgentProfile(payload) {
+  if (!payload || !payload.id) {
+    throw new Error('Ajan kaydı için benzersiz bir kimlik gereklidir.');
+  }
+
+  return upsertAgentProfile(payload.id, payload);
+}
+
+// Mevcut bir ajan profilini güncelleyen yardımcı.
+function updateAgentProfile(id, updates) {
+  if (!getAgentProfile(id)) {
+    throw new Error('Ajan profili bulunamadı.');
+  }
+
+  return upsertAgentProfile(id, updates || {});
+}
+
+// Ajan profillerini filtreleyerek döndüren yardımcı.
+function listAgentProfilesWithFilters(filters = {}) {
+  const collection = listAgentProfiles();
+  if (!filters.projectId) {
+    return collection;
+  }
+
+  return Object.fromEntries(
+    Object.entries(collection).filter(([, agent]) => agent.projectId === filters.projectId)
+  );
+}
+
+// Belirli bir ajan profilini döndüren yardımcı.
+function getAgentProfileById(id) {
+  return getAgentProfile(id);
+}
+
+// Bir ajan profilini proje ile eşleyen yardımcı.
+function linkProfileToProject(agentId, projectId) {
+  const linked = linkAgentToProject(agentId, projectId);
+  if (!linked) {
+    throw new Error('Ajan profili bulunamadı.');
+  }
+
+  return linked;
+}
+
+// Bir ajan profilini kaldıran yardımcı.
+function removeAgentProfile(id) {
+  return deleteAgentProfile(id);
+}
+
+module.exports = {
+  registerAgentProfile,
+  updateAgentProfile,
+  listAgentProfilesWithFilters,
+  getAgentProfileById,
+  linkProfileToProject,
+  removeAgentProfile
+};

--- a/src/services/automationRunner.js
+++ b/src/services/automationRunner.js
@@ -1,6 +1,11 @@
 // App Lab Agent - Ajan görevlerini n8n iş akışları ve dağıtım tetikleyicilerine kuyruklayan otomasyon yürütücüsü.
 
-const { upsertTask } = require('../data/memoryStore');
+const {
+  upsertTask,
+  getBuild,
+  upsertBuild,
+  appendBuildHistory
+} = require('../data/memoryStore');
 const n8nConnector = require('../connectors/n8nConnector');
 const hostingerConnector = require('../connectors/hostingerConnector');
 
@@ -19,6 +24,34 @@ function processNext() {
   }
 
   const job = inMemoryQueue.shift();
+
+  if (job?.type === 'build') {
+    const { buildId, payload } = job;
+    const build = getBuild(buildId);
+    if (!build) {
+      return null;
+    }
+
+    appendBuildHistory(buildId, {
+      status: 'building',
+      notes: payload?.notes || 'Derleme süreci başladı'
+    });
+    upsertBuild(buildId, {
+      status: 'building'
+    });
+
+    appendBuildHistory(buildId, {
+      status: 'built',
+      notes: payload?.completionNotes || 'Derleme başarıyla tamamlandı'
+    });
+    const artifactUrl =
+      payload?.artifactUrl || `https://cdn.applabagent.net/artifacts/${buildId}.zip`;
+    return upsertBuild(buildId, {
+      status: 'built',
+      artifactUrl
+    });
+  }
+
   const { taskId, definition, context } = job;
 
   const workflowId = definition?.workflowId;

--- a/src/services/automationRunner.js
+++ b/src/services/automationRunner.js
@@ -44,8 +44,13 @@ function pendingJobs() {
   return [...inMemoryQueue];
 }
 
+function resetQueue() {
+  inMemoryQueue.splice(0, inMemoryQueue.length);
+}
+
 module.exports = {
   enqueue,
   processNext,
-  pendingJobs
+  pendingJobs,
+  resetQueue
 };

--- a/src/services/automationRunner.js
+++ b/src/services/automationRunner.js
@@ -1,0 +1,51 @@
+// App Lab Agent - Ajan görevlerini n8n iş akışları ve dağıtım tetikleyicilerine kuyruklayan otomasyon yürütücüsü.
+
+const { upsertTask } = require('../data/memoryStore');
+const n8nConnector = require('../connectors/n8nConnector');
+const hostingerConnector = require('../connectors/hostingerConnector');
+
+const inMemoryQueue = [];
+
+function enqueue(job) {
+  inMemoryQueue.push({
+    ...job,
+    enqueuedAt: new Date().toISOString()
+  });
+}
+
+function processNext() {
+  if (!inMemoryQueue.length) {
+    return null;
+  }
+
+  const job = inMemoryQueue.shift();
+  const { taskId, definition, context } = job;
+
+  const workflowId = definition?.workflowId;
+  if (workflowId) {
+    n8nConnector.triggerWorkflow(workflowId, context);
+  }
+
+  if (definition?.deploymentTarget) {
+    hostingerConnector.triggerDeployment(definition.deploymentTarget);
+  }
+
+  const result = upsertTask(taskId, {
+    ...definition,
+    status: 'processed',
+    lastRunAt: new Date().toISOString(),
+    lastContext: context
+  });
+
+  return result;
+}
+
+function pendingJobs() {
+  return [...inMemoryQueue];
+}
+
+module.exports = {
+  enqueue,
+  processNext,
+  pendingJobs
+};

--- a/src/services/buildService.js
+++ b/src/services/buildService.js
@@ -1,0 +1,116 @@
+// App Lab Agent - Mobil ve web uygulamaları için derleme yaşam döngüsünü yöneten servis katmanı.
+
+const {
+  getProject,
+  getWorkflow,
+  upsertBuild,
+  getBuild,
+  listBuilds,
+  appendBuildHistory
+} = require('../data/memoryStore');
+const automationRunner = require('./automationRunner');
+
+function createBuild(payload) {
+  const { projectId, platform, version, workflowId, releaseChannel } = payload;
+  if (!projectId || !platform || !version) {
+    throw new Error('projectId, platform ve version alanları zorunludur');
+  }
+
+  const project = getProject(projectId);
+  if (!project) {
+    throw new Error('Proje bulunamadı');
+  }
+
+  if (workflowId) {
+    const workflow = getWorkflow(workflowId);
+    if (!workflow) {
+      throw new Error('İlgili iş akışı bulunamadı');
+    }
+  }
+
+  const id = `build_${Date.now()}`;
+  const build = upsertBuild(id, {
+    projectId,
+    platform,
+    version,
+    workflowId: workflowId || null,
+    releaseChannel: releaseChannel || null,
+    status: 'queued',
+    artifactUrl: null,
+    notes: payload?.notes || null
+  });
+
+  appendBuildHistory(id, {
+    status: 'queued',
+    notes: payload?.notes || 'Derleme kuyruğa alındı'
+  });
+
+  return build;
+}
+
+function triggerBuild(buildId, options = {}) {
+  const build = getBuild(buildId);
+  if (!build) {
+    throw new Error('Derleme kaydı bulunamadı');
+  }
+
+  automationRunner.enqueue({
+    type: 'build',
+    buildId,
+    payload: {
+      notes: options?.notes,
+      completionNotes: options?.completionNotes,
+      artifactUrl: options?.artifactUrl
+    }
+  });
+
+  return build;
+}
+
+function updateBuildStatus(buildId, updates) {
+  const build = getBuild(buildId);
+  if (!build) {
+    throw new Error('Derleme kaydı bulunamadı');
+  }
+
+  if (updates?.status) {
+    appendBuildHistory(buildId, {
+      status: updates.status,
+      notes: updates?.notes
+    });
+  }
+
+  return upsertBuild(buildId, updates);
+}
+
+function listBuildsForQuery(query = {}) {
+  const builds = Object.values(listBuilds());
+  return builds.filter((build) => {
+    if (query.projectId && build.projectId !== query.projectId) {
+      return false;
+    }
+    if (query.platform && build.platform !== query.platform) {
+      return false;
+    }
+    if (query.status && build.status !== query.status) {
+      return false;
+    }
+    return true;
+  });
+}
+
+function getBuildById(buildId) {
+  const build = getBuild(buildId);
+  if (!build) {
+    throw new Error('Derleme kaydı bulunamadı');
+  }
+  return build;
+}
+
+module.exports = {
+  createBuild,
+  triggerBuild,
+  updateBuildStatus,
+  listBuildsForQuery,
+  getBuildById
+};

--- a/src/services/environmentService.js
+++ b/src/services/environmentService.js
@@ -1,0 +1,87 @@
+// App Lab Agent - Domain, dağıtım ve yayın kanalı yapılandırmalarını koordine eden ortam servis modülü.
+
+const store = require('../data/memoryStore');
+
+function validateDomain(domain) {
+  if (!domain || typeof domain !== 'string') {
+    throw new Error('Alan adı değeri zorunludur.');
+  }
+
+  const sanitized = domain.trim().toLowerCase();
+  const domainRegex = /^(?!-)[a-z0-9-]+(\.[a-z0-9-]+)+$/;
+  if (!domainRegex.test(sanitized)) {
+    throw new Error('Geçersiz alan adı formatı.');
+  }
+
+  return sanitized;
+}
+
+function getEnvironmentSnapshot() {
+  const environment = store.getEnvironment();
+  const hostinger = store.getConnection('hostinger');
+
+  return {
+    domain: environment.domain,
+    releaseChannels: environment.releaseChannels,
+    updatedAt: environment.updatedAt,
+    hostinger: {
+      status: hostinger?.status || 'disconnected',
+      siteId: hostinger?.metadata?.siteId || null,
+      domainLinked: hostinger?.metadata?.domain === environment.domain
+    }
+  };
+}
+
+function updateDomain(domain) {
+  const sanitized = validateDomain(domain);
+  const environment = store.updateEnvironment({ domain: sanitized });
+
+  const hostinger = store.getConnection('hostinger');
+  if (hostinger) {
+    store.setConnection('hostinger', {
+      ...hostinger,
+      metadata: {
+        ...hostinger.metadata,
+        domain: sanitized
+      }
+    });
+  }
+
+  return environment;
+}
+
+function registerReleaseChannel(platform, configuration) {
+  if (!platform || typeof platform !== 'string') {
+    throw new Error('Platform değeri zorunludur.');
+  }
+
+  if (!configuration || typeof configuration !== 'object') {
+    throw new Error('Yayın kanalı yapılandırması zorunludur.');
+  }
+
+  const allowedPlatforms = ['android', 'ios', 'web'];
+  const normalizedPlatform = platform.trim().toLowerCase();
+  if (!allowedPlatforms.includes(normalizedPlatform)) {
+    throw new Error('Desteklenmeyen yayın platformu.');
+  }
+
+  const requiredKeysByPlatform = {
+    android: ['packageName', 'track'],
+    ios: ['bundleId', 'ascAppId'],
+    web: ['deploymentTarget']
+  };
+
+  const requiredKeys = requiredKeysByPlatform[normalizedPlatform] || [];
+  const missing = requiredKeys.filter((key) => !configuration[key]);
+  if (missing.length) {
+    throw new Error(`Eksik yapılandırma alanları: ${missing.join(', ')}`);
+  }
+
+  return store.upsertReleaseChannel(normalizedPlatform, configuration);
+}
+
+module.exports = {
+  getEnvironmentSnapshot,
+  updateDomain,
+  registerReleaseChannel
+};

--- a/src/services/pipelineService.js
+++ b/src/services/pipelineService.js
@@ -1,0 +1,270 @@
+// App Lab Agent - Proje, derleme, sürüm ve dağıtım adımlarını uçtan uca koordine eden pipeline servis modülü.
+
+const store = require('../data/memoryStore');
+const projectService = require('./projectService');
+const buildService = require('./buildService');
+const releaseService = require('./releaseService');
+const environmentService = require('./environmentService');
+const automationRunner = require('./automationRunner');
+const githubConnector = require('../connectors/githubConnector');
+const hostingerConnector = require('../connectors/hostingerConnector');
+const n8nConnector = require('../connectors/n8nConnector');
+
+function ensureIntegrationsConnected() {
+  const integrations = {
+    github: githubConnector.getStatus(),
+    hostinger: hostingerConnector.getStatus(),
+    n8n: n8nConnector.getStatus()
+  };
+
+  const missing = Object.entries(integrations)
+    .filter(([, status]) => status?.status !== 'connected')
+    .map(([provider]) => provider);
+
+  if (missing.length) {
+    throw new Error(`Eksik entegrasyon bağlantıları: ${missing.join(', ')}`);
+  }
+
+  return integrations;
+}
+
+function normalizePlatforms(input, environment) {
+  if (Array.isArray(input) && input.length) {
+    return input.map((platform) => platform.trim().toLowerCase());
+  }
+
+  if (input && typeof input === 'object') {
+    return Object.keys(input).map((platform) => platform.trim().toLowerCase());
+  }
+
+  const configured = Object.keys(environment?.releaseChannels || {});
+  if (configured.length) {
+    return configured;
+  }
+
+  return ['web'];
+}
+
+function deriveReleaseChannel(platform, environment, overrides = {}) {
+  if (overrides?.releaseChannel) {
+    return overrides.releaseChannel;
+  }
+
+  const envChannel = environment?.releaseChannels?.[platform] || {};
+  return (
+    overrides?.track ||
+    overrides?.deploymentTarget ||
+    envChannel.track ||
+    envChannel.deploymentTarget ||
+    envChannel.ascAppId ||
+    envChannel.packageName ||
+    null
+  );
+}
+
+function appendRunStep(runId, step) {
+  const current = store.getPipelineRun(runId) || {};
+  const steps = [
+    ...(current.steps || []),
+    {
+      ...step,
+      timestamp: step?.timestamp || new Date().toISOString()
+    }
+  ];
+
+  store.upsertPipelineRun(runId, { steps });
+  return store.getPipelineRun(runId);
+}
+
+function planDelivery(options = {}) {
+  const { projectId, version = '1.0.0', platforms, workflowId, releaseChannels = {}, notes } = options;
+  if (!projectId) {
+    throw new Error('Pipeline planı için projectId değeri zorunludur.');
+  }
+
+  const project = projectService.getProject(projectId);
+  const integrations = ensureIntegrationsConnected();
+  const environment = environmentService.getEnvironmentSnapshot();
+  const normalizedPlatforms = normalizePlatforms(platforms, environment);
+
+  const release = releaseService.createRelease({
+    projectId: project.id,
+    version,
+    platforms: normalizedPlatforms,
+    notes: notes || `${project.name || project.id} ${version} pipeline planı`
+  });
+
+  const builds = normalizedPlatforms.map((platform) => {
+    const platformConfig = !Array.isArray(platforms) && platforms?.[platform] ? platforms[platform] : {};
+    const releaseChannel = deriveReleaseChannel(platform, environment, {
+      ...platformConfig,
+      releaseChannel: releaseChannels?.[platform]
+    });
+
+    return buildService.createBuild({
+      projectId: project.id,
+      platform,
+      version,
+      workflowId: platformConfig?.workflowId || workflowId || null,
+      releaseChannel,
+      notes: platformConfig?.notes || notes || `Pipeline ${platform} derlemesi`
+    });
+  });
+
+  builds.forEach((build) => {
+    releaseService.assignPlatformBuild(release.id, build.platform, build.id, 'pipeline');
+  });
+
+  const pipelineId = `pipeline_${Date.now()}`;
+  const record = store.upsertPipelineRun(pipelineId, {
+    projectId: project.id,
+    version,
+    status: 'planned',
+    releaseId: release.id,
+    builds: builds.map((build) => ({ id: build.id, platform: build.platform })),
+    integrations,
+    domain: environment.domain,
+    notes: notes || null
+  });
+
+  const plannedRecord = appendRunStep(record.id, {
+    type: 'planned',
+    message: 'Pipeline planı oluşturuldu'
+  });
+
+  return {
+    pipelineId: plannedRecord.id,
+    status: plannedRecord.status,
+    project,
+    release: releaseService.getReleaseDetail(release.id),
+    builds,
+    environment,
+    integrations,
+    steps: plannedRecord.steps
+  };
+}
+
+function executeDelivery(options = {}) {
+  const { pipelineId, automationWorkflowId, autoDeploy = false, deploymentTarget = 'production', processQueue = true } = options;
+
+  let planRecord = pipelineId ? store.getPipelineRun(pipelineId) : null;
+  if (!planRecord) {
+    const plan = planDelivery(options);
+    planRecord = store.getPipelineRun(plan.pipelineId);
+  }
+
+  if (!planRecord) {
+    throw new Error('Pipeline planı bulunamadı.');
+  }
+
+  const triggeredBuilds = [];
+  const processedBuilds = [];
+
+  planRecord.builds.forEach((entry) => {
+    const triggered = buildService.triggerBuild(entry.id, {
+      notes: `Pipeline ${planRecord.id} build tetiklemesi`,
+      completionNotes: `Pipeline ${planRecord.id} build tamamlandı`
+    });
+    triggeredBuilds.push(triggered);
+  });
+
+  if (processQueue) {
+    let processed;
+    do {
+      processed = automationRunner.processNext();
+      if (processed && planRecord.builds.some((entry) => entry.id === processed.id)) {
+        processedBuilds.push(processed);
+      }
+    } while (processed);
+  }
+
+  const platformUpdates = planRecord.builds.map((entry) =>
+    releaseService.updatePlatformStatus(
+      planRecord.releaseId,
+      entry.platform,
+      {
+        status: processQueue ? 'ready_for_submission' : 'waiting_for_build',
+        storeStatus: processQueue ? 'ready' : 'pending'
+      },
+      'pipeline'
+    )
+  );
+
+  const promoted = releaseService.promoteRelease(
+    planRecord.releaseId,
+    processQueue ? 'in_review' : 'planned',
+    'pipeline',
+    processQueue
+      ? 'Otomatik pipeline sürümü inceleme aşamasına taşıdı'
+      : 'Pipeline planı oluşturuldu'
+  );
+
+  let deploymentResult = null;
+  if (autoDeploy) {
+    deploymentResult = hostingerConnector.triggerDeployment(deploymentTarget);
+  }
+
+  let automationTrigger = null;
+  if (automationWorkflowId) {
+    automationTrigger = n8nConnector.triggerWorkflow(automationWorkflowId, {
+      projectId: planRecord.projectId,
+      releaseId: planRecord.releaseId,
+      builds: planRecord.builds
+    });
+  }
+
+  const completed = store.upsertPipelineRun(planRecord.id, {
+    status: processQueue ? 'completed' : 'queued',
+    completedAt: processQueue ? new Date().toISOString() : null,
+    lastExecution: {
+      triggeredBuilds: triggeredBuilds.map((build) => build.id),
+      processedBuilds: processedBuilds.map((build) => build.id),
+      releaseStatus: promoted.status,
+      deployment: deploymentResult,
+      automationTrigger
+    }
+  });
+
+  const executedRecord = appendRunStep(planRecord.id, {
+    type: 'executed',
+    message: processQueue ? 'Pipeline çalıştırması tamamlandı' : 'Pipeline kuyruğa alındı'
+  });
+
+  const environment = environmentService.getEnvironmentSnapshot();
+
+  return {
+    pipelineId: executedRecord.id,
+    status: executedRecord.status,
+    release: releaseService.getReleaseDetail(planRecord.releaseId),
+    builds: planRecord.builds.map((entry) => buildService.getBuildById(entry.id)),
+    releasePlatforms: platformUpdates,
+    environment,
+    integrations: planRecord.integrations,
+    deployment: deploymentResult,
+    automationTrigger,
+    steps: executedRecord.steps
+  };
+}
+
+function listPipelineRuns() {
+  const runs = store.listPipelineRuns();
+  return Object.values(runs).sort((a, b) => new Date(b.updatedAt) - new Date(a.updatedAt));
+}
+
+function getPipelineRunDetail(id) {
+  if (!id) {
+    throw new Error('Pipeline detayı için id değeri zorunludur.');
+  }
+  const run = store.getPipelineRun(id);
+  if (!run) {
+    throw new Error(`Pipeline kaydı bulunamadı: ${id}`);
+  }
+  return run;
+}
+
+module.exports = {
+  planDelivery,
+  executeDelivery,
+  listPipelineRuns,
+  getPipelineRunDetail
+};

--- a/src/services/projectService.js
+++ b/src/services/projectService.js
@@ -1,0 +1,97 @@
+// App Lab Agent - Proje yaşam döngüsünü, entegrasyon bağlarını ve görev eşleştirmelerini yöneten servis katmanı.
+
+const {
+  upsertProject,
+  getProject,
+  listProjects,
+  getTask
+} = require('../data/memoryStore');
+
+function ensureProjectExists(projectId) {
+  const project = getProject(projectId);
+  if (!project) {
+    throw new Error(`Proje bulunamadı: ${projectId}`);
+  }
+  return project;
+}
+
+function createProject(projectId, payload = {}) {
+  if (!projectId) {
+    throw new Error('Proje oluşturmak için kimlik gereklidir.');
+  }
+
+  const baseTimestamp = new Date().toISOString();
+
+  return upsertProject(projectId, {
+    id: projectId,
+    name: payload.name || 'Yeni App Lab Projesi',
+    description: payload.description || '',
+    integrations: payload.integrations || {},
+    tasks: payload.tasks || [],
+    createdAt: baseTimestamp
+  });
+}
+
+function linkIntegration(projectId, provider, details = {}) {
+  if (!provider) {
+    throw new Error('Proje entegrasyonu için sağlayıcı değeri zorunludur.');
+  }
+
+  const project = ensureProjectExists(projectId);
+
+  const integrations = {
+    ...project.integrations,
+    [provider]: {
+      ...details,
+      linkedAt: new Date().toISOString()
+    }
+  };
+
+  return upsertProject(projectId, {
+    ...project,
+    integrations
+  });
+}
+
+function registerTaskMapping(projectId, taskId, options = {}) {
+  if (!taskId) {
+    throw new Error('Proje görev eşlemesi için görev kimliği gereklidir.');
+  }
+
+  const project = ensureProjectExists(projectId);
+  const task = getTask(taskId);
+  if (!task) {
+    throw new Error(`Görev bulunamadı: ${taskId}`);
+  }
+
+  const tasks = project.tasks || [];
+  const existingIndex = tasks.findIndex((item) => item.taskId === taskId);
+  const mapping = {
+    taskId,
+    runPolicy: options.runPolicy || 'manual',
+    lastRunAt: options.lastRunAt || null
+  };
+
+  if (existingIndex >= 0) {
+    tasks.splice(existingIndex, 1, { ...tasks[existingIndex], ...mapping });
+  } else {
+    tasks.push(mapping);
+  }
+
+  return upsertProject(projectId, {
+    ...project,
+    tasks: [...tasks]
+  });
+}
+
+function listProjectSummaries() {
+  return Object.values(listProjects());
+}
+
+module.exports = {
+  createProject,
+  linkIntegration,
+  registerTaskMapping,
+  listProjectSummaries,
+  getProject: ensureProjectExists
+};

--- a/src/services/releaseService.js
+++ b/src/services/releaseService.js
@@ -1,0 +1,170 @@
+// App Lab Agent - Çoklu platform sürüm yönetimi servis katmanı; yayın süreçlerini, platform durumlarını ve geçmiş kayıtlarını yönetir.
+
+const {
+  upsertRelease,
+  getRelease,
+  listReleases,
+  upsertReleasePlatform,
+  appendReleaseHistory,
+  getProject,
+  getBuild
+} = require('../data/memoryStore');
+
+function ensureReleaseExists(releaseId) {
+  const release = getRelease(releaseId);
+  if (!release) {
+    throw new Error(`Sürüm kaydı bulunamadı: ${releaseId}`);
+  }
+  return release;
+}
+
+function createRelease({ id, projectId, version, platforms = [], notes } = {}) {
+  if (projectId) {
+    const project = getProject(projectId);
+    if (!project) {
+      throw new Error(`Sürüm için belirtilen proje bulunamadı: ${projectId}`);
+    }
+  }
+
+  const releaseId = id || `rel-${Date.now()}`;
+
+  const base = upsertRelease(releaseId, {
+    projectId: projectId || null,
+    version: version || '0.0.1',
+    status: 'draft',
+    notes: notes || '',
+    history: []
+  });
+
+  const normalizedPlatforms = Array.isArray(platforms)
+    ? platforms
+    : typeof platforms === 'object' && platforms !== null
+      ? Object.keys(platforms)
+      : [];
+
+  normalizedPlatforms.forEach((platform) => {
+    upsertReleasePlatform(releaseId, platform, {
+      status: 'pending',
+      storeStatus: 'not_submitted'
+    });
+  });
+
+  appendReleaseHistory(releaseId, {
+    type: 'created',
+    message: `${base.version} sürümü oluşturuldu`,
+    actor: 'system'
+  });
+
+  return getRelease(releaseId);
+}
+
+function listReleaseSummaries({ projectId } = {}) {
+  const releases = Object.values(listReleases() || {});
+
+  return releases
+    .filter((release) => {
+      if (!projectId) {
+        return true;
+      }
+      return release.projectId === projectId;
+    })
+    .map((release) => ({
+      id: release.id,
+      projectId: release.projectId,
+      version: release.version,
+      status: release.status,
+      platforms: release.platforms,
+      updatedAt: release.updatedAt
+    }));
+}
+
+function getReleaseDetail(releaseId) {
+  return ensureReleaseExists(releaseId);
+}
+
+function assignPlatformBuild(releaseId, platform, buildId, actor = 'system') {
+  ensureReleaseExists(releaseId);
+  if (!platform) {
+    throw new Error('Platform belirtilmelidir.');
+  }
+
+  const build = getBuild(buildId);
+  if (!build) {
+    throw new Error(`Bağlanacak build bulunamadı: ${buildId}`);
+  }
+
+  const platformState = upsertReleasePlatform(releaseId, platform, {
+    buildId,
+    status: 'in_progress',
+    storeStatus: 'not_submitted'
+  });
+
+  appendReleaseHistory(releaseId, {
+    type: 'build_assigned',
+    platform,
+    message: `${platform} platformu için ${buildId} build'i ilişkilendirildi`,
+    actor
+  });
+
+  return platformState;
+}
+
+function updatePlatformStatus(releaseId, platform, updates = {}, actor = 'system') {
+  ensureReleaseExists(releaseId);
+  if (!platform) {
+    throw new Error('Platform belirtilmelidir.');
+  }
+
+  const platformState = upsertReleasePlatform(releaseId, platform, updates);
+  appendReleaseHistory(releaseId, {
+    type: 'platform_update',
+    platform,
+    message: updates?.message || `${platform} platform durumu güncellendi`,
+    actor,
+    details: {
+      status: platformState.status,
+      storeStatus: platformState.storeStatus
+    }
+  });
+
+  return platformState;
+}
+
+function promoteRelease(releaseId, status, actor = 'system', message) {
+  const release = ensureReleaseExists(releaseId);
+  if (!status) {
+    throw new Error('Yeni sürüm durumunu belirtmelisiniz.');
+  }
+
+  const updated = upsertRelease(releaseId, {
+    status
+  });
+
+  appendReleaseHistory(releaseId, {
+    type: 'status_change',
+    message: message || `${release.version} sürüm durumu ${status} olarak güncellendi`,
+    actor,
+    details: { previous: release.status, current: status }
+  });
+
+  return updated;
+}
+
+function recordMilestone(releaseId, entry) {
+  ensureReleaseExists(releaseId);
+  appendReleaseHistory(releaseId, {
+    type: 'milestone',
+    ...entry
+  });
+  return getRelease(releaseId);
+}
+
+module.exports = {
+  createRelease,
+  listReleaseSummaries,
+  getReleaseDetail,
+  assignPlatformBuild,
+  updatePlatformStatus,
+  promoteRelease,
+  recordMilestone
+};

--- a/src/services/statusService.js
+++ b/src/services/statusService.js
@@ -1,0 +1,222 @@
+// App Lab Agent - Platformun genel durumunu ve son etkinlik özetlerini hesaplayan durum servisi.
+
+const store = require('../data/memoryStore');
+const githubConnector = require('../connectors/githubConnector');
+const hostingerConnector = require('../connectors/hostingerConnector');
+const n8nConnector = require('../connectors/n8nConnector');
+
+function toArray(collection) {
+  return Object.values(collection || {});
+}
+
+function countBy(items, key) {
+  return items.reduce((acc, item) => {
+    const value = item?.[key] || 'unknown';
+    acc[value] = (acc[value] || 0) + 1;
+    return acc;
+  }, {});
+}
+
+function resolveTimestamp(item) {
+  return (
+    item?.updatedAt ||
+    item?.completedAt ||
+    item?.timestamp ||
+    item?.createdAt ||
+    null
+  );
+}
+
+function buildRecentActivityCollection() {
+  const activity = [];
+
+  toArray(store.listProjects()).forEach((project) => {
+    activity.push({
+      type: 'project',
+      id: project.id,
+      name: project.name,
+      status: project.status || 'active',
+      updatedAt: resolveTimestamp(project),
+      metadata: {
+        integrationCount: Object.keys(project.integrations || {}).length,
+        taskCount: (project.tasks || []).length
+      }
+    });
+  });
+
+  toArray(store.listWorkflows()).forEach((workflow) => {
+    activity.push({
+      type: 'workflow',
+      id: workflow.id,
+      name: workflow.name,
+      status: 'configured',
+      updatedAt: resolveTimestamp(workflow),
+      metadata: {
+        projectId: workflow.projectId || null,
+        taskCount: (workflow.tasks || []).length
+      }
+    });
+  });
+
+  toArray(store.listTasks()).forEach((task) => {
+    activity.push({
+      type: 'task',
+      id: task.id,
+      name: task.id,
+      status: task.status || 'registered',
+      updatedAt: resolveTimestamp(task),
+      metadata: {
+        lastRunAt: task.lastRunAt || null
+      }
+    });
+  });
+
+  toArray(store.listAgentProfiles()).forEach((agent) => {
+    activity.push({
+      type: 'agent',
+      id: agent.id,
+      name: agent.name,
+      status: 'ready',
+      updatedAt: resolveTimestamp(agent),
+      metadata: {
+        provider: agent.provider,
+        projectId: agent.projectId || null
+      }
+    });
+  });
+
+  toArray(store.listBuilds()).forEach((build) => {
+    activity.push({
+      type: 'build',
+      id: build.id,
+      name: `${build.platform || 'build'}-${build.version || ''}`.trim(),
+      status: build.status || 'unknown',
+      updatedAt: resolveTimestamp(build),
+      metadata: {
+        projectId: build.projectId || null,
+        platform: build.platform || null
+      }
+    });
+  });
+
+  toArray(store.listReleases()).forEach((release) => {
+    activity.push({
+      type: 'release',
+      id: release.id,
+      name: release.version,
+      status: release.status || 'draft',
+      updatedAt: resolveTimestamp(release),
+      metadata: {
+        projectId: release.projectId || null,
+        platformCount: Object.keys(release.platforms || {}).length
+      }
+    });
+  });
+
+  toArray(store.listPipelineRuns()).forEach((run) => {
+    activity.push({
+      type: 'pipeline',
+      id: run.id,
+      name: run.version || run.id,
+      status: run.status || 'planned',
+      updatedAt: resolveTimestamp(run),
+      metadata: {
+        projectId: run.projectId || null,
+        releaseId: run.releaseId || null
+      }
+    });
+  });
+
+  return activity
+    .filter((item) => item.updatedAt)
+    .sort((a, b) => new Date(b.updatedAt) - new Date(a.updatedAt));
+}
+
+function getRecentActivity(limit = 10) {
+  const normalizedLimit = Number.isFinite(limit) && limit > 0 ? limit : 10;
+  return buildRecentActivityCollection().slice(0, normalizedLimit);
+}
+
+function buildPlatformSummary() {
+  const now = new Date().toISOString();
+  const environment = store.getEnvironment();
+
+  const connections = {
+    github: githubConnector.getStatus(),
+    hostinger: hostingerConnector.getStatus(),
+    n8n: n8nConnector.getStatus()
+  };
+
+  const projects = toArray(store.listProjects());
+  const workflows = toArray(store.listWorkflows());
+  const tasks = toArray(store.listTasks());
+  const agents = toArray(store.listAgentProfiles());
+  const builds = toArray(store.listBuilds());
+  const releases = toArray(store.listReleases());
+  const pipelineRuns = toArray(store.listPipelineRuns());
+
+  const sortedPipelineRuns = [...pipelineRuns].sort(
+    (a, b) => new Date(b.updatedAt || 0) - new Date(a.updatedAt || 0)
+  );
+
+  return {
+    generatedAt: now,
+    environment: {
+      domain: environment.domain,
+      updatedAt: environment.updatedAt,
+      releaseChannelCount: Object.keys(environment.releaseChannels || {}).length,
+      releaseChannels: environment.releaseChannels || {}
+    },
+    connections: {
+      details: connections,
+      connectedProviders: Object.entries(connections)
+        .filter(([, status]) => status?.status === 'connected')
+        .map(([provider]) => provider),
+      disconnectedProviders: Object.entries(connections)
+        .filter(([, status]) => status?.status !== 'connected')
+        .map(([provider]) => provider)
+    },
+    projects: {
+      total: projects.length,
+      withIntegrations: projects.filter((project) => Object.keys(project.integrations || {}).length > 0).length,
+      ids: projects.map((project) => project.id)
+    },
+    automations: {
+      workflows: {
+        total: workflows.length,
+        attachedToProjects: workflows.filter((workflow) => Boolean(workflow.projectId)).length
+      },
+      tasks: {
+        total: tasks.length,
+        queued: tasks.filter((task) => task.status === 'queued').length
+      }
+    },
+    agents: {
+      total: agents.length,
+      byProvider: countBy(agents, 'provider')
+    },
+    builds: {
+      total: builds.length,
+      byStatus: countBy(builds, 'status')
+    },
+    releases: {
+      total: releases.length,
+      byStatus: countBy(releases, 'status')
+    },
+    pipelines: {
+      total: pipelineRuns.length,
+      lastRunAt: sortedPipelineRuns[0]?.updatedAt || null,
+      recent: sortedPipelineRuns.slice(0, 3).map((run) => ({
+        id: run.id,
+        status: run.status,
+        updatedAt: run.updatedAt
+      }))
+    },
+    recentActivity: getRecentActivity(5)
+  };
+}
+
+module.exports = {
+  buildPlatformSummary,
+  getRecentActivity
+};

--- a/src/services/workflowService.js
+++ b/src/services/workflowService.js
@@ -1,0 +1,85 @@
+// App Lab Agent - Otomasyon iş akışlarını yöneten, görev bağlantıları ve tetiklemeleri sağlayan servis katmanı.
+
+const {
+  upsertWorkflow,
+  getWorkflow,
+  listWorkflows,
+  getTask
+} = require('../data/memoryStore');
+const automationRunner = require('./automationRunner');
+
+function ensureWorkflowExists(workflowId) {
+  const workflow = getWorkflow(workflowId);
+  if (!workflow) {
+    throw new Error(`İş akışı bulunamadı: ${workflowId}`);
+  }
+  return workflow;
+}
+
+function registerWorkflow(workflowId, payload = {}) {
+  if (!workflowId) {
+    throw new Error('İş akışı kaydı için kimlik gereklidir.');
+  }
+
+  return upsertWorkflow(workflowId, {
+    id: workflowId,
+    name: payload.name || 'Yeni Otomasyon',
+    description: payload.description || '',
+    definition: payload.definition || {},
+    projectId: payload.projectId || null,
+    tasks: payload.tasks || []
+  });
+}
+
+function attachTask(workflowId, taskId) {
+  if (!taskId) {
+    throw new Error('İş akışına bağlanacak görev kimliği gereklidir.');
+  }
+
+  const workflow = ensureWorkflowExists(workflowId);
+  const task = getTask(taskId);
+  if (!task) {
+    throw new Error(`Görev bulunamadı: ${taskId}`);
+  }
+
+  const tasks = workflow.tasks || [];
+  if (!tasks.includes(taskId)) {
+    tasks.push(taskId);
+  }
+
+  return upsertWorkflow(workflowId, {
+    ...workflow,
+    tasks
+  });
+}
+
+function trigger(workflowId, context = {}) {
+  const workflow = ensureWorkflowExists(workflowId);
+
+  automationRunner.enqueue({
+    taskId: `workflow:${workflowId}`,
+    definition: {
+      workflowId,
+      deploymentTarget: workflow.definition?.deploymentTarget || null
+    },
+    context
+  });
+
+  return {
+    workflowId,
+    enqueuedAt: new Date().toISOString(),
+    context
+  };
+}
+
+function listAllWorkflows() {
+  return Object.values(listWorkflows());
+}
+
+module.exports = {
+  registerWorkflow,
+  attachTask,
+  trigger,
+  listAllWorkflows,
+  getWorkflow: ensureWorkflowExists
+};

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "commonjs",
+    "lib": ["es2022"],
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "moduleResolution": "node",
+    "baseUrl": "src",
+    "esModuleInterop": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "paths": {
+      "@/*": ["*"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tests/aiAgentService.test.js
+++ b/tests/aiAgentService.test.js
@@ -1,0 +1,54 @@
+// App Lab Agent - Yapay zeka ajan servisini doğrulayan testler.
+
+const test = require('node:test');
+const assert = require('node:assert');
+
+const store = require('../src/data/memoryStore');
+const agentService = require('../src/services/aiAgentService');
+
+test.beforeEach(() => {
+  store.reset();
+});
+
+test('ajan profili oluşturma ve güncelleme', () => {
+  const created = agentService.registerAgentProfile({
+    id: 'agent-1',
+    name: 'Mobil Uzmanı',
+    provider: 'openai',
+    model: 'gpt-4.1',
+    capabilities: ['build', 'deploy']
+  });
+
+  assert.strictEqual(created.id, 'agent-1');
+  assert.deepStrictEqual(created.capabilities, ['build', 'deploy']);
+
+  const updated = agentService.updateAgentProfile('agent-1', {
+    capabilities: ['build', 'deploy', 'qa'],
+    instructions: 'Tüm testleri çalıştır ve raporla.'
+  });
+
+  assert.strictEqual(updated.instructions, 'Tüm testleri çalıştır ve raporla.');
+  assert.deepStrictEqual(updated.capabilities, ['build', 'deploy', 'qa']);
+});
+
+test('ajan profillerini projeye göre filtreleme', () => {
+  agentService.registerAgentProfile({ id: 'agent-a', projectId: 'proj-1' });
+  agentService.registerAgentProfile({ id: 'agent-b', projectId: 'proj-2' });
+
+  const all = agentService.listAgentProfilesWithFilters();
+  assert.strictEqual(Object.keys(all).length, 2);
+
+  const filtered = agentService.listAgentProfilesWithFilters({ projectId: 'proj-1' });
+  assert.deepStrictEqual(Object.keys(filtered), ['agent-a']);
+});
+
+test('ajanı projeye bağlama ve silme', () => {
+  agentService.registerAgentProfile({ id: 'agent-x' });
+
+  const linked = agentService.linkProfileToProject('agent-x', 'proj-9');
+  assert.strictEqual(linked.projectId, 'proj-9');
+
+  const removed = agentService.removeAgentProfile('agent-x');
+  assert.strictEqual(removed, true);
+  assert.strictEqual(agentService.getAgentProfileById('agent-x'), null);
+});

--- a/tests/buildService.test.js
+++ b/tests/buildService.test.js
@@ -1,0 +1,85 @@
+// App Lab Agent - Derleme servisinin uçtan uca davranışını doğrulayan test senaryoları.
+
+const test = require('node:test');
+const assert = require('node:assert');
+
+const memoryStore = require('../src/data/memoryStore');
+const projectService = require('../src/services/projectService');
+const buildService = require('../src/services/buildService');
+const automationRunner = require('../src/services/automationRunner');
+
+function resetState() {
+  memoryStore.reset();
+  automationRunner.resetQueue();
+}
+
+test('derleme oluşturma ve sorgulama filtreleri çalışır', () => {
+  resetState();
+  projectService.createProject('app-demo', { name: 'Demo' });
+
+  const build = buildService.createBuild({
+    projectId: 'app-demo',
+    platform: 'android',
+    version: '1.0.0',
+    notes: 'İlk deneme'
+  });
+
+  assert.strictEqual(build.status, 'queued');
+  assert.strictEqual(build.projectId, 'app-demo');
+  assert.ok(Array.isArray(build.history));
+  assert.strictEqual(build.history.length, 1);
+
+  const builds = buildService.listBuildsForQuery({ projectId: 'app-demo', platform: 'android' });
+  assert.strictEqual(builds.length, 1);
+  assert.strictEqual(builds[0].version, '1.0.0');
+});
+
+test('derleme tetikleme kuyruğu otomatik olarak tamamlanmış bir artefact üretir', () => {
+  resetState();
+  projectService.createProject('app-demo');
+
+  const build = buildService.createBuild({
+    projectId: 'app-demo',
+    platform: 'ios',
+    version: '1.2.3'
+  });
+
+  buildService.triggerBuild(build.id, {
+    notes: 'Beta build başlatıldı',
+    completionNotes: 'CI pipeline başarıyla tamamlandı',
+    artifactUrl: 'https://cdn.example.com/app-demo/ios/app.ipa'
+  });
+
+  const processed = automationRunner.processNext();
+  assert.strictEqual(processed.status, 'built');
+  assert.strictEqual(processed.artifactUrl, 'https://cdn.example.com/app-demo/ios/app.ipa');
+
+  const stored = buildService.getBuildById(build.id);
+  assert.strictEqual(stored.status, 'built');
+  assert.strictEqual(stored.history.length, 3);
+  assert.strictEqual(stored.history[0].status, 'queued');
+  assert.strictEqual(stored.history[1].status, 'building');
+  assert.strictEqual(stored.history[2].status, 'built');
+});
+
+test('manuel durum güncellemesi geçmiş kaydını genişletir', () => {
+  resetState();
+  projectService.createProject('app-demo');
+
+  const build = buildService.createBuild({
+    projectId: 'app-demo',
+    platform: 'android',
+    version: '2.0.0'
+  });
+
+  const updated = buildService.updateBuildStatus(build.id, {
+    status: 'failed',
+    notes: 'Derleme aşamasında test hatası'
+  });
+
+  assert.strictEqual(updated.status, 'failed');
+  const stored = buildService.getBuildById(build.id);
+  assert.strictEqual(stored.history.length, 2);
+  assert.strictEqual(stored.history[1].status, 'failed');
+  assert.strictEqual(stored.history[1].notes, 'Derleme aşamasında test hatası');
+});

--- a/tests/environmentService.test.js
+++ b/tests/environmentService.test.js
@@ -1,0 +1,40 @@
+// App Lab Agent - Ortam servisi alan adı ve yayın kanalı davranışlarını doğrulayan testler.
+
+const test = require('node:test');
+const assert = require('node:assert');
+
+const store = require('../src/data/memoryStore');
+const environmentService = require('../src/services/environmentService');
+const hostingerConnector = require('../src/connectors/hostingerConnector');
+
+test.beforeEach(() => {
+  store.reset();
+});
+
+test('Varsayılan ortam özeti alan adını ve bağlantı durumunu döndürür', () => {
+  const snapshot = environmentService.getEnvironmentSnapshot();
+  assert.strictEqual(snapshot.domain, 'applabagent.net');
+  assert.strictEqual(snapshot.hostinger.status, 'disconnected');
+});
+
+test('Alan adı güncellemesi Hostinger meta verisiyle senkronize edilir', () => {
+  hostingerConnector.connect('hostinger-key', 'site-xyz');
+  const updated = environmentService.updateDomain('AppLabAgent.net');
+
+  assert.strictEqual(updated.domain, 'applabagent.net');
+
+  const hostingerStatus = hostingerConnector.getStatus();
+  assert.strictEqual(hostingerStatus.metadata.domain, 'applabagent.net');
+});
+
+test('Yayın kanalı kaydı zorunlu alanları doğrular', () => {
+  const channel = environmentService.registerReleaseChannel('android', {
+    packageName: 'com.applabagent.mobile',
+    track: 'internal'
+  });
+  assert.strictEqual(channel.packageName, 'com.applabagent.mobile');
+
+  assert.throws(() => {
+    environmentService.registerReleaseChannel('ios', { bundleId: 'com.applabagent.ios' });
+  }, /Eksik yapılandırma alanları/);
+});

--- a/tests/hostingerConnector.test.js
+++ b/tests/hostingerConnector.test.js
@@ -1,0 +1,84 @@
+// App Lab Agent - Hostinger konektörünün bağlantı ve altyapı senkronizasyon davranışlarını doğrulayan testler.
+
+const test = require('node:test');
+const assert = require('node:assert');
+
+const store = require('../src/data/memoryStore');
+const hostingerConnector = require('../src/connectors/hostingerConnector');
+
+test.beforeEach(() => {
+  store.reset();
+  global.fetch = undefined;
+});
+
+test('Hostinger bağlantısı API anahtarı ve alan adı meta verisini saklar', () => {
+  const connection = hostingerConnector.connect('token-123', 'site-987', 'AppLabAgent.NET');
+
+  assert.strictEqual(connection.metadata.domain, 'applabagent.net');
+  assert.strictEqual(connection.metadata.apiKey, 'token-123');
+});
+
+test('Sanal sunucu listesi varsayılan bağlantı anahtarını kullanır', async () => {
+  hostingerConnector.connect('token-abc', 'site-000');
+
+  const mockedResponse = {
+    ok: true,
+    json: async () => ({
+      data: [
+        { id: 'vm-1', name: 'Production orchestrator' },
+        { id: 'vm-2', name: 'Preview edge node' }
+      ],
+      meta: { total: 2, per_page: 25 }
+    })
+  };
+
+  let receivedUrl;
+  let receivedHeaders;
+  global.fetch = async (url, options) => {
+    receivedUrl = url;
+    receivedHeaders = options?.headers;
+    return mockedResponse;
+  };
+
+  const result = await hostingerConnector.listVirtualMachines();
+
+  assert.match(receivedUrl, /\/api\/vps\/v1\/virtual-machines/);
+  assert.strictEqual(receivedHeaders.Authorization, 'Bearer token-abc');
+  assert.strictEqual(result.meta.total, 2);
+  assert.strictEqual(result.machines.length, 2);
+});
+
+test('Sanal sunucu listesi başarısız HTTP durumunda hata döndürür', async () => {
+  hostingerConnector.connect('token-def', 'site-123');
+
+  global.fetch = async () => ({
+    ok: false,
+    status: 401,
+    statusText: 'Unauthorized',
+    text: async () => 'invalid token'
+  });
+
+  await assert.rejects(() => hostingerConnector.listVirtualMachines(), (error) => {
+    assert.match(error.message, /Hostinger API hatası \(401\)/);
+    assert.match(error.message, /invalid token/);
+    return true;
+  });
+});
+
+test('Harici anahtar ile sayfalı istek yapılabilir', async () => {
+  global.fetch = async (url) => {
+    const parsed = new URL(url);
+    assert.strictEqual(parsed.searchParams.get('page'), '3');
+    return {
+      ok: true,
+      json: async () => ({ items: [] })
+    };
+  };
+
+  const result = await hostingerConnector.listVirtualMachines({ apiKey: 'external-key', page: 3 });
+  assert.deepStrictEqual(result.machines, []);
+});
+
+test.after(() => {
+  delete global.fetch;
+});

--- a/tests/orchestrator.test.js
+++ b/tests/orchestrator.test.js
@@ -12,6 +12,7 @@ const automationRunner = require('../src/services/automationRunner');
 
 test.beforeEach(() => {
   store.reset();
+  automationRunner.resetQueue();
 });
 
 test('GitHub entegrasyon bağlantısı durumu', () => {

--- a/tests/orchestrator.test.js
+++ b/tests/orchestrator.test.js
@@ -50,4 +50,7 @@ test('Ajan görevi kaydı, dispatch ve kuyruk işleme', () => {
   const processed = automationRunner.processNext();
   assert.strictEqual(processed.status, 'processed');
   assert.strictEqual(processed.deploymentTarget, 'staging');
+
+  const deployment = hostingerConnector.triggerDeployment('production');
+  assert.strictEqual(deployment.domain, 'applabagent.net');
 });

--- a/tests/orchestrator.test.js
+++ b/tests/orchestrator.test.js
@@ -1,0 +1,52 @@
+// App Lab Agent - Orkestrasyon servisinin bağlantı ve kuyruk işleyişini doğrulayan temel testler.
+
+const test = require('node:test');
+const assert = require('node:assert');
+
+const store = require('../src/data/memoryStore');
+const githubConnector = require('../src/connectors/githubConnector');
+const n8nConnector = require('../src/connectors/n8nConnector');
+const hostingerConnector = require('../src/connectors/hostingerConnector');
+const orchestrator = require('../src/services/agentOrchestrator');
+const automationRunner = require('../src/services/automationRunner');
+
+test.beforeEach(() => {
+  store.reset();
+});
+
+test('GitHub entegrasyon bağlantısı durumu', () => {
+  githubConnector.connect('fake-token', { repo: 'app', organization: 'lab' });
+  const status = githubConnector.getStatus();
+  assert.strictEqual(status.status, 'connected');
+  assert.strictEqual(status.metadata.repo, 'app');
+});
+
+test('n8n ve Hostinger entegrasyonları kurulmadan görev çalıştırılamaz', () => {
+  assert.throws(() => {
+    n8nConnector.triggerWorkflow('wf-1', {});
+  }, /bağlantı kurulmalıdır/);
+
+  assert.throws(() => {
+    hostingerConnector.triggerDeployment('production');
+  }, /bağlantı kurulmalıdır/);
+});
+
+test('Ajan görevi kaydı, dispatch ve kuyruk işleme', () => {
+  n8nConnector.connect('https://n8n.local', 'apikey');
+  hostingerConnector.connect('hostinger-key', 'site-123');
+
+  const definition = {
+    workflowId: 'wf-123',
+    deploymentTarget: 'staging'
+  };
+
+  orchestrator.registerTask('build-release', definition);
+  orchestrator.dispatchTask('build-release', { branch: 'main' });
+
+  const pending = automationRunner.pendingJobs();
+  assert.strictEqual(pending.length, 1);
+
+  const processed = automationRunner.processNext();
+  assert.strictEqual(processed.status, 'processed');
+  assert.strictEqual(processed.deploymentTarget, 'staging');
+});

--- a/tests/pipelineService.test.js
+++ b/tests/pipelineService.test.js
@@ -1,0 +1,87 @@
+// App Lab Agent - Pipeline servisinin uçtan uca davranışını doğrulayan test senaryoları.
+
+const test = require('node:test');
+const assert = require('node:assert');
+
+const memoryStore = require('../src/data/memoryStore');
+const automationRunner = require('../src/services/automationRunner');
+const projectService = require('../src/services/projectService');
+const environmentService = require('../src/services/environmentService');
+const pipelineService = require('../src/services/pipelineService');
+const githubConnector = require('../src/connectors/githubConnector');
+const hostingerConnector = require('../src/connectors/hostingerConnector');
+const n8nConnector = require('../src/connectors/n8nConnector');
+
+function resetState() {
+  memoryStore.reset();
+  automationRunner.resetQueue();
+}
+
+test('entegrasyon bağlantıları olmadan pipeline planlanamaz', () => {
+  resetState();
+  projectService.createProject('pipeline-demo');
+
+  assert.throws(
+    () => pipelineService.planDelivery({ projectId: 'pipeline-demo' }),
+    /Eksik entegrasyon bağlantıları/
+  );
+});
+
+test('pipeline yürütmesi derlemeleri tamamlayıp sürümü terfi ettirir', () => {
+  resetState();
+
+  projectService.createProject('pipeline-demo', { name: 'Pipeline Demo Projesi' });
+  environmentService.registerReleaseChannel('android', {
+    packageName: 'com.applab.pipeline',
+    track: 'internal'
+  });
+  environmentService.registerReleaseChannel('ios', {
+    bundleId: 'com.applab.pipeline.ios',
+    ascAppId: '123456789'
+  });
+  environmentService.registerReleaseChannel('web', {
+    deploymentTarget: 'production'
+  });
+
+  githubConnector.connect('gh-token', { repo: 'applab-agent', organization: 'applab' });
+  hostingerConnector.connect('hk-token', 'site-001', 'applabagent.net');
+  n8nConnector.connect('https://n8n.applabagent.net', 'n8n-token');
+
+  const plan = pipelineService.planDelivery({
+    projectId: 'pipeline-demo',
+    version: '1.5.0',
+    platforms: ['android', 'web'],
+    notes: 'QA öncesi pipeline planı'
+  });
+
+  assert.strictEqual(plan.status, 'planned');
+  assert.strictEqual(plan.builds.length, 2);
+  assert.ok(plan.steps.some((step) => step.type === 'planned'));
+
+  const execution = pipelineService.executeDelivery({
+    pipelineId: plan.pipelineId,
+    autoDeploy: true,
+    deploymentTarget: 'production',
+    automationWorkflowId: 'ops-notify'
+  });
+
+  assert.strictEqual(execution.status, 'completed');
+  assert.strictEqual(execution.builds.length, 2);
+  execution.builds.forEach((build) => {
+    assert.strictEqual(build.status, 'built');
+    assert.ok(build.artifactUrl.includes(build.id));
+  });
+
+  assert.strictEqual(execution.release.status, 'in_review');
+  assert.strictEqual(execution.releasePlatforms.length, 2);
+  assert.ok(execution.deployment);
+  assert.strictEqual(execution.deployment.status, 'deployment_requested');
+  assert.ok(execution.automationTrigger);
+  assert.strictEqual(execution.automationTrigger.status, 'workflow_triggered');
+  assert.ok(execution.steps.some((step) => step.type === 'executed'));
+
+  const runs = pipelineService.listPipelineRuns();
+  assert.strictEqual(runs.length, 1);
+  assert.strictEqual(runs[0].status, 'completed');
+  assert.strictEqual(runs[0].lastExecution.releaseStatus, 'in_review');
+});

--- a/tests/projectService.test.js
+++ b/tests/projectService.test.js
@@ -1,0 +1,45 @@
+// App Lab Agent - Proje servisinin temel yaşam döngüsü senaryolarını doğrulayan testler.
+
+const test = require('node:test');
+const assert = require('node:assert');
+
+const store = require('../src/data/memoryStore');
+const orchestrator = require('../src/services/agentOrchestrator');
+const projectService = require('../src/services/projectService');
+
+test.beforeEach(() => {
+  store.reset();
+});
+
+test('proje oluşturma ve listeleme', () => {
+  const project = projectService.createProject('proj-1', {
+    name: 'Test Projesi',
+    description: 'Mobil uygulama denemesi'
+  });
+
+  assert.strictEqual(project.id, 'proj-1');
+  assert.strictEqual(project.name, 'Test Projesi');
+
+  const list = projectService.listProjectSummaries();
+  assert.strictEqual(list.length, 1);
+});
+
+test('proje entegrasyonu ve görev eşlemesi', () => {
+  projectService.createProject('proj-2');
+
+  orchestrator.registerTask('build', { workflowId: 'wf-10' });
+
+  const withIntegration = projectService.linkIntegration('proj-2', 'github', {
+    repo: 'awesome-app'
+  });
+
+  assert.ok(withIntegration.integrations.github);
+  assert.strictEqual(withIntegration.integrations.github.repo, 'awesome-app');
+
+  const updatedProject = projectService.registerTaskMapping('proj-2', 'build', {
+    runPolicy: 'auto'
+  });
+
+  assert.strictEqual(updatedProject.tasks.length, 1);
+  assert.strictEqual(updatedProject.tasks[0].runPolicy, 'auto');
+});

--- a/tests/releaseService.test.js
+++ b/tests/releaseService.test.js
@@ -1,0 +1,93 @@
+// App Lab Agent - Çoklu platform sürüm servisinin davranışlarını doğrulayan testler.
+
+const test = require('node:test');
+const assert = require('node:assert');
+
+const memoryStore = require('../src/data/memoryStore');
+const projectService = require('../src/services/projectService');
+const buildService = require('../src/services/buildService');
+const releaseService = require('../src/services/releaseService');
+
+function resetState() {
+  memoryStore.reset();
+}
+
+test('sürüm oluşturma platform varsayılanlarını üretir', () => {
+  resetState();
+  projectService.createProject('proj-1', { name: 'Mobil Uygulama' });
+
+  const release = releaseService.createRelease({
+    id: 'rel-1',
+    projectId: 'proj-1',
+    version: '1.0.0',
+    platforms: ['android', 'ios'],
+    notes: 'İlk canlı dağıtım'
+  });
+
+  assert.strictEqual(release.id, 'rel-1');
+  assert.strictEqual(release.projectId, 'proj-1');
+  assert.strictEqual(release.version, '1.0.0');
+  assert.strictEqual(release.status, 'draft');
+  assert.ok(Array.isArray(release.history));
+  assert.strictEqual(release.history.length, 1);
+  assert.ok(release.platforms.android);
+  assert.strictEqual(release.platforms.android.status, 'pending');
+  assert.ok(release.platforms.ios);
+});
+
+test('build ilişkilendirme platform durumunu günceller', () => {
+  resetState();
+  projectService.createProject('proj-2');
+  const build = buildService.createBuild({
+    id: 'build-android',
+    projectId: 'proj-2',
+    platform: 'android',
+    version: '1.0.1'
+  });
+
+  releaseService.createRelease({
+    id: 'rel-2',
+    projectId: 'proj-2',
+    platforms: ['android']
+  });
+
+  const platformState = releaseService.assignPlatformBuild('rel-2', 'android', build.id, 'release-bot');
+  assert.strictEqual(platformState.buildId, build.id);
+  assert.strictEqual(platformState.status, 'in_progress');
+  assert.strictEqual(platformState.storeStatus, 'not_submitted');
+
+  const afterUpdate = releaseService.updatePlatformStatus(
+    'rel-2',
+    'android',
+    {
+      status: 'submitted',
+      storeStatus: 'in_review',
+      submissionNotes: 'Google Play Console gönderimi tamamlandı',
+      message: 'Android build incelemede'
+    },
+    'release-manager'
+  );
+
+  assert.strictEqual(afterUpdate.status, 'submitted');
+  assert.strictEqual(afterUpdate.storeStatus, 'in_review');
+  assert.strictEqual(afterUpdate.submissionNotes, 'Google Play Console gönderimi tamamlandı');
+
+  const releaseDetail = releaseService.getReleaseDetail('rel-2');
+  assert.strictEqual(releaseDetail.history.length, 3);
+});
+
+test('sürüm statü terfisi listede yansır', () => {
+  resetState();
+  projectService.createProject('proj-3');
+
+  releaseService.createRelease({ id: 'rel-3', projectId: 'proj-3', version: '2.0.0' });
+  releaseService.createRelease({ id: 'rel-4', projectId: 'proj-3', version: '2.1.0' });
+
+  releaseService.promoteRelease('rel-3', 'in_progress', 'ops');
+  releaseService.promoteRelease('rel-3', 'published', 'ops');
+
+  const summaries = releaseService.listReleaseSummaries({ projectId: 'proj-3' });
+  assert.strictEqual(summaries.length, 2);
+  const published = summaries.find((item) => item.id === 'rel-3');
+  assert.strictEqual(published.status, 'published');
+});

--- a/tests/statusRoutes.test.js
+++ b/tests/statusRoutes.test.js
@@ -1,0 +1,44 @@
+// App Lab Agent - Durum yönlendiricisinin HTTP taleplerine verdiği yanıtları doğrulayan testler.
+
+const test = require('node:test');
+const assert = require('node:assert');
+
+const store = require('../src/data/memoryStore');
+const automationRunner = require('../src/services/automationRunner');
+const statusRoutes = require('../src/routes/statusRoutes');
+const projectService = require('../src/services/projectService');
+const githubConnector = require('../src/connectors/githubConnector');
+const hostingerConnector = require('../src/connectors/hostingerConnector');
+const n8nConnector = require('../src/connectors/n8nConnector');
+const pipelineService = require('../src/services/pipelineService');
+
+test.beforeEach(() => {
+  store.reset();
+  automationRunner.resetQueue();
+});
+
+test('GET /api/status/summary varsayılan boş özet döndürür', async () => {
+  const response = await statusRoutes.route({ method: 'GET', pathname: '/api/status/summary', query: {} });
+  assert.strictEqual(response.status, 200);
+  assert.strictEqual(response.data.projects.total, 0);
+});
+
+test('GET /api/status/recent-activity limit parametresini uygular', async () => {
+  githubConnector.connect('gh-token', { repo: 'demo', organization: 'applab' });
+  hostingerConnector.connect('host-token', 'site-001');
+  n8nConnector.connect('https://n8n.local', 'n8n-token');
+
+  const project = projectService.createProject('suite', { name: 'Suite' });
+  const plan = pipelineService.planDelivery({ projectId: project.id, version: '2.0.0', platforms: ['android'] });
+  pipelineService.executeDelivery({ pipelineId: plan.pipelineId, processQueue: true });
+
+  const response = await statusRoutes.route({
+    method: 'GET',
+    pathname: '/api/status/recent-activity',
+    query: { limit: '2' }
+  });
+
+  assert.strictEqual(response.status, 200);
+  assert.ok(Array.isArray(response.data));
+  assert.ok(response.data.length <= 2);
+});

--- a/tests/statusService.test.js
+++ b/tests/statusService.test.js
@@ -1,0 +1,86 @@
+// App Lab Agent - Durum servisinin platform özeti ve etkinlik listesi üretmesini doğrulayan testler.
+
+const test = require('node:test');
+const assert = require('node:assert');
+
+const store = require('../src/data/memoryStore');
+const automationRunner = require('../src/services/automationRunner');
+const githubConnector = require('../src/connectors/githubConnector');
+const hostingerConnector = require('../src/connectors/hostingerConnector');
+const n8nConnector = require('../src/connectors/n8nConnector');
+const projectService = require('../src/services/projectService');
+const orchestrator = require('../src/services/agentOrchestrator');
+const workflowService = require('../src/services/workflowService');
+const agentService = require('../src/services/aiAgentService');
+const pipelineService = require('../src/services/pipelineService');
+const statusService = require('../src/services/statusService');
+
+test.beforeEach(() => {
+  store.reset();
+  automationRunner.resetQueue();
+});
+
+test('Varsayılan platform özeti bağlantı durumlarını ve sıfır kayıtları döndürür', () => {
+  const summary = statusService.buildPlatformSummary();
+
+  assert.strictEqual(summary.environment.domain, 'applabagent.net');
+  assert.deepStrictEqual(summary.connections.details.github.status, 'disconnected');
+  assert.strictEqual(summary.projects.total, 0);
+  assert.strictEqual(summary.builds.total, 0);
+  assert.strictEqual(summary.recentActivity.length, 0);
+});
+
+test('Özet, kayıtlı projeler ve pipeline çalıştırmalarıyla güncellenir', () => {
+  githubConnector.connect('gh-token', { repo: 'demo', organization: 'applab' });
+  hostingerConnector.connect('host-token', 'site-001');
+  n8nConnector.connect('https://n8n.local', 'n8n-token');
+
+  const project = projectService.createProject('demo-app', { name: 'Demo App' });
+  orchestrator.registerTask('prepare-build', { type: 'automation' });
+  workflowService.registerWorkflow('wf-release', { projectId: project.id, tasks: ['prepare-build'] });
+  agentService.registerAgentProfile({ id: 'ops-agent', name: 'Operations', provider: 'openai', projectId: project.id });
+
+  const plan = pipelineService.planDelivery({
+    projectId: project.id,
+    version: '1.2.3',
+    platforms: ['android', 'ios']
+  });
+
+  pipelineService.executeDelivery({ pipelineId: plan.pipelineId, processQueue: true });
+
+  const summary = statusService.buildPlatformSummary();
+
+  assert.strictEqual(summary.projects.total, 1);
+  assert.strictEqual(summary.automations.workflows.total, 1);
+  assert.strictEqual(summary.agents.total, 1);
+  assert.ok(summary.builds.total >= 1);
+  assert.strictEqual(summary.releases.total, 1);
+  assert.strictEqual(summary.pipelines.total, 1);
+  assert.ok(summary.pipelines.lastRunAt);
+  assert.ok(summary.recentActivity.length > 0);
+  assert.ok(summary.connections.connectedProviders.includes('github'));
+  assert.ok(summary.connections.connectedProviders.includes('hostinger'));
+  assert.ok(summary.connections.connectedProviders.includes('n8n'));
+});
+
+test('Son etkinlik listesi zaman damgasına göre sıralanır ve limit uygulanır', () => {
+  githubConnector.connect('gh-token', { repo: 'demo', organization: 'applab' });
+  hostingerConnector.connect('host-token', 'site-001');
+  n8nConnector.connect('https://n8n.local', 'n8n-token');
+
+  const project = projectService.createProject('mobile-suite', { name: 'Mobile Suite' });
+  orchestrator.registerTask('mobile-build', { type: 'automation' });
+  workflowService.registerWorkflow('wf-mobile', { projectId: project.id, tasks: ['mobile-build'] });
+
+  const plan = pipelineService.planDelivery({ projectId: project.id, version: '3.0.0', platforms: ['android'] });
+  pipelineService.executeDelivery({ pipelineId: plan.pipelineId, processQueue: true });
+
+  const fullActivity = statusService.getRecentActivity();
+  assert.ok(fullActivity.some((item) => item.type === 'pipeline'));
+
+  const limited = statusService.getRecentActivity(3);
+  assert.ok(limited.length <= 3);
+  const timestamps = limited.map((item) => item.updatedAt);
+  const sorted = [...timestamps].sort((a, b) => new Date(b) - new Date(a));
+  assert.deepStrictEqual(timestamps, sorted);
+});

--- a/tests/workflowService.test.js
+++ b/tests/workflowService.test.js
@@ -1,0 +1,48 @@
+// App Lab Agent - İş akışı servisinin kayıt, görev bağlama ve tetikleme süreçlerini doğrulayan testler.
+
+const test = require('node:test');
+const assert = require('node:assert');
+
+const store = require('../src/data/memoryStore');
+const orchestrator = require('../src/services/agentOrchestrator');
+const workflowService = require('../src/services/workflowService');
+const automationRunner = require('../src/services/automationRunner');
+
+test.beforeEach(() => {
+  store.reset();
+  automationRunner.resetQueue();
+});
+
+test('iş akışı kaydı ve listeleme', () => {
+  const workflow = workflowService.registerWorkflow('wf-1', {
+    name: 'Yayın hattı',
+    description: 'Test ve dağıtım otomasyonu'
+  });
+
+  assert.strictEqual(workflow.id, 'wf-1');
+  assert.strictEqual(workflow.name, 'Yayın hattı');
+
+  const list = workflowService.listAllWorkflows();
+  assert.strictEqual(list.length, 1);
+});
+
+test('iş akışına görev bağlama', () => {
+  orchestrator.registerTask('lint', { workflowId: 'wf-2' });
+  workflowService.registerWorkflow('wf-2');
+
+  const result = workflowService.attachTask('wf-2', 'lint');
+
+  assert.ok(result.tasks.includes('lint'));
+});
+
+test('iş akışı tetikleme kuyruğu', () => {
+  workflowService.registerWorkflow('wf-queue', {
+    definition: { deploymentTarget: 'app-lab' }
+  });
+
+  const response = workflowService.trigger('wf-queue', { branch: 'main' });
+
+  assert.strictEqual(response.workflowId, 'wf-queue');
+  assert.strictEqual(automationRunner.pendingJobs().length, 1);
+  assert.strictEqual(automationRunner.pendingJobs()[0].definition.workflowId, 'wf-queue');
+});


### PR DESCRIPTION
## Summary
- extend the in-memory store with project records alongside tasks and integrations
- add a project service and HTTP routes to manage project lifecycle, integrations, and task mappings
- document the new endpoints and cover the workflow with project-centric unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d508636ae883339bc96ff78b503d55