### PR TITLE
Add navigation menu audit helpers for frontend menus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,113 @@
 # AppLabAgent
-App Lab Agent bir yapay zeka ajanlarını kullnarak insanların hem test hem uygulama yapabilecekleri hesapları baglayıp github hostinger n8n otomasyanlarını ve diğe ryapay zeka ajanlarını kullanıp uygulama cıkarbilecekleri bir uygulama geliştirme firmasına ait ve domain hosting ve kendi uygulamalarını geliştirdikleri bir uygulama 
+
+App Lab Agent, yapay zeka destekli uygulama geliştirme süreçlerinde hesap bağlantıları,
+projeler ve otomasyon akışlarını tek noktadan yönetmeye odaklanan modüler bir Python
+paketidir. Paket, hesapları güvenli biçimde kaydetmek, projeleri planlamak ve otomasyon
+reçetelerini doğrulamak için hafif bileşenler sunar.
+
+## Özellikler
+
+- Harici servis hesaplarını `AccountRegistry` ile kayıt altına alma ve serileştirme.
+- `ProjectWorkspace` sayesinde görev panoları olan projeler oluşturma ve hesap bağlama.
+- Proje görevlerini `start_task`, `block_task` ve `complete_task` kısayollarıyla ilerletme.
+- Sorumlu bazlı görev raporları ve iş yükü özetleriyle ekip kapasitesini planlama.
+- Yol haritası yönetimi için kilometre taşları ekleyip tamamlayarak teslim tarihlerini takip etme.
+- Teslim tarihi geçmiş kilometre taşlarını raporlayarak riskleri erken yakalama.
+- `AutomationStudio` ile otomasyon tariflerini doğrulama ve n8n uyumlu çıktılar alma.
+- `AppLabAgentPlatform` sınıfı ile tüm bileşenleri orkestre ederek uçtan uca senaryoları
+  yönetme.
+- Teknoloji yığınlarını bağlı hesap ve otomasyonlarla eşleştirmek için
+  `integration_audit` raporuyla entegrasyon boşluklarını izleme.
+- Frontend ön izlemeleri için `project_workspace` ve `TaskBoard.export_tasks`
+  yardımcılarıyla pano verilerini JSON olarak çıkarma.
+- `DatabaseSchema` sayesinde platform durumunu sözlük olarak dışa aktarma ve tekrar
+  yükleme.
+- Frontend menülerini `navigation_menu` ile üretip eksik bölümleri hızla tespit etme.
+
+## Kurulum
+
+Projeyi sisteminize klonladıktan sonra Python 3.11+ sürümüne sahip olduğunuzdan emin olun.
+Gerekli bağımlılık yalnızca `pytest` olduğu için aşağıdaki komutla yükleyebilirsiniz:
+
+```bash
+pip install pytest
+```
+
+## Testler
+
+Tüm testleri çalıştırmak için:
+
+```bash
+pytest
+```
+
+## Hızlı Örnek
+
+```python
+from app_lab_agent import AppLabAgentPlatform
+
+platform = AppLabAgentPlatform()
+platform.link_account("github", "studio", {"plan": "team"})
+platform.create_project(
+    name="Automation",
+    description="Müşteriler için otomasyon platformu",
+    tech_stack=["python", "n8n"],
+    goals=["MVP"],
+    tasks=[
+        {
+            "identifier": "setup-ci",
+            "title": "CI hattını kur",
+            "description": "Test ve kalite kontrolleri ekle",
+            "owner": "Leyla",
+        },
+        {
+            "identifier": "draft-spec",
+            "title": "Özeti yaz",
+            "description": "Beklenen akışları dokümante et",
+        },
+    ],
+)
+platform.add_project_milestone(
+    "Automation",
+    title="Demo sunumu",
+    due_date="2025-01-15",
+    description="İlk müşteri demosunu hazırlama",
+)
+platform.create_automation(
+    name="Deploy bot",
+    trigger="pull_request",
+    actions=["lint", "deploy"],
+    required_accounts=["github:studio"],
+)
+summary = platform.portfolio_overview()
+upcoming = platform.upcoming_project_milestones(limit=3)
+overdue = platform.overdue_project_milestones(reference_date="2025-02-01")
+owner_report = platform.list_tasks_for_owner("Leyla", include_unassigned=True)
+workload = platform.owner_workload_report(include_unassigned=True)
+integration_gaps = platform.integration_audit()
+menu_status = platform.navigation_menu()
+
+# Platform durumunu kalıcı hale getirmek için veriyi şemalaştırma
+from app_lab_agent.storage import DatabaseSchema
+
+schema = DatabaseSchema.from_platform(platform)
+snapshot = schema.to_dict()
+restored_platform = DatabaseSchema.from_dict(snapshot).to_platform()
+```
+
+Bu örnek, temel hesap ve proje yapılandırmasını oluşturup platform özetini üretir.
+`owner_workload_report` çıktısı ise sorumlulara göre görev adetlerini ve durum dağılımını
+proje kırılımıyla birlikte sağlar. `integration_audit` ise teknoloji yığınındaki her
+kalemin kayıtlı hesaplar ve otomasyonlarla eşleşip eşleşmediğini denetleyerek eksik
+entegrasyonları hızlıca yakalamanıza yardımcı olur. `navigation_menu` sonucu ise frontend
+arayüzlerinde gösterilecek menü bölümlerini ve boş kalan alanları bildirerek eksik
+verilerin kolayca tamamlanmasını sağlar.
+
+## Frontend ile Entegrasyon
+
+AppLabAgent yalnızca Python API'leri sağlar; ancak bu API'leri HTTP servisleri üzerinden
+frontend uygulamalarına aktarabilirsiniz. FastAPI veya Flask gibi hafif çerçeveler ile
+`AppLabAgentPlatform` verilerini JSON olarak sunarak görev panolarını, kilometre taşı
+listelerini ve iş yükü raporlarını web arayüzlerinde gösterebilirsiniz. Ayrıntılı adımlar
+ve örnek kodlar için [`docs/frontend_integration.md`](docs/frontend_integration.md)
+dosyasına göz atın.

--- a/app_lab_agent/__init__.py
+++ b/app_lab_agent/__init__.py
@@ -1,0 +1,44 @@
+"""App Lab Agent paketinin genel modül başlatıcısı."""
+
+# Paket seviyesindeki bileşenleri dışa aktarıyoruz.
+from .accounts import AccountRegistry, AccountRegistryError, LinkedAccount
+from .tasks import TaskBoard, Task, TaskStatus
+from .projects import (
+    ProjectWorkspace,
+    ProjectBlueprint,
+    ProjectWorkspaceError,
+    Milestone,
+    MilestoneStatus,
+)
+from .automation import AutomationRecipe, AutomationStudio, AutomationValidationError
+from .platform import AppLabAgentPlatform, AppLabAgentError
+from .navigation import NavigationMenu, NavigationMenuError, MenuItem, MenuSection
+from .storage import AccountRecord, AutomationRecord, DatabaseSchema, ProjectRecord, TaskRecord
+
+__all__ = [
+    "AccountRegistry",
+    "AccountRegistryError",
+    "LinkedAccount",
+    "TaskBoard",
+    "Task",
+    "TaskStatus",
+    "ProjectWorkspace",
+    "ProjectBlueprint",
+    "ProjectWorkspaceError",
+    "Milestone",
+    "MilestoneStatus",
+    "AutomationRecipe",
+    "AutomationStudio",
+    "AutomationValidationError",
+    "AccountRecord",
+    "TaskRecord",
+    "ProjectRecord",
+    "AutomationRecord",
+    "DatabaseSchema",
+    "AppLabAgentPlatform",
+    "AppLabAgentError",
+    "NavigationMenu",
+    "NavigationMenuError",
+    "MenuItem",
+    "MenuSection",
+]

--- a/app_lab_agent/accounts.py
+++ b/app_lab_agent/accounts.py
@@ -1,0 +1,149 @@
+"""App Lab Agent platformunda hesap bağlantılarını yönetmek için yardımcılar sağlar."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Dict, Iterable, List, Mapping, MutableMapping, Optional, Tuple
+
+
+# Hesap bağlantılarının saklanmasında kullanılan özel hata türü.
+class AccountRegistryError(RuntimeError):
+    """Hesap kayıt işlemleri sırasında oluşan hataları temsil eder."""
+
+
+# Harici servisler için tutulacak hesap meta verisini modelleyen veri sınıfı.
+@dataclass(frozen=True)
+class LinkedAccount:
+    """Bir entegre servis hesabına ait temel bilgileri taşır."""
+
+    provider: str
+    name: str
+    metadata: Mapping[str, str]
+    tags: Tuple[str, ...] = ()
+
+    # Meta veriyi güncelleyen yardımcı fonksiyon.
+    def with_metadata(self, **metadata: str) -> "LinkedAccount":
+        """Var olan meta veriye yeni alanlar eklenmiş kopyayı döndürür."""
+
+        new_metadata = dict(self.metadata)
+        new_metadata.update(metadata)
+        return replace(self, metadata=new_metadata)
+
+
+# Bağlı hesapları hafızada saklayıp hızlı erişim sağlayan kayıt defteri sınıfı.
+class AccountRegistry:
+    """Harici servis hesaplarının kaydını tutar ve sorgular."""
+
+    def __init__(self, accounts: Optional[Iterable[LinkedAccount]] = None) -> None:
+        self._accounts: MutableMapping[Tuple[str, str], LinkedAccount] = {}
+        if accounts:
+            for account in accounts:
+                self.register(account.provider, account.name, account.metadata, account.tags)
+
+    # Hesap kaydeden ana yardımcı metot.
+    def register(
+        self,
+        provider: str,
+        name: str,
+        metadata: Optional[Mapping[str, str]] = None,
+        tags: Optional[Iterable[str]] = None,
+    ) -> LinkedAccount:
+        """Yeni bir hesabı kayıt altına alır; aynı anahtar varsa hata döndürür."""
+
+        key = self._normalise_key(provider, name)
+        if key in self._accounts:
+            raise AccountRegistryError(
+                f"{provider!r} sağlayıcısı için {name!r} adına sahip hesap zaten kayıtlı."
+            )
+
+        metadata = metadata or {}
+        account = LinkedAccount(provider=provider, name=name, metadata=dict(metadata), tags=tuple(tags or ()))
+        self._accounts[key] = account
+        return account
+
+    # Hesap meta verisini güncelleyen yardımcı metot.
+    def update_metadata(self, provider: str, name: str, **metadata: str) -> LinkedAccount:
+        """Belirtilen hesabın meta verisine yeni alanlar ekleyerek günceller."""
+
+        key = self._normalise_key(provider, name)
+        account = self._ensure_exists(key)
+        updated = account.with_metadata(**metadata)
+        self._accounts[key] = updated
+        return updated
+
+    # Hesabı kayıt defterinden silen metot.
+    def remove(self, provider: str, name: str) -> LinkedAccount:
+        """İlgili hesabı kaldırır ve kaldırılan örneği döndürür."""
+
+        key = self._normalise_key(provider, name)
+        account = self._ensure_exists(key)
+        del self._accounts[key]
+        return account
+
+    # Hesap detaylarını sorgulamaya yarayan metot.
+    def get(self, provider: str, name: str) -> LinkedAccount:
+        """Sağlayıcı ve ad bilgisine göre hesabı döndürür."""
+
+        key = self._normalise_key(provider, name)
+        return self._ensure_exists(key)
+
+    # Kayıtlı hesapları listeleyen metot.
+    def list_accounts(self, provider: Optional[str] = None) -> List[LinkedAccount]:
+        """Tüm hesapları veya belirli sağlayıcıya ait olanları sıralı şekilde döndürür."""
+
+        if provider is None:
+            values = list(self._accounts.values())
+        else:
+            provider_key = provider.lower()
+            values = [acc for acc in self._accounts.values() if acc.provider.lower() == provider_key]
+        return sorted(values, key=lambda acc: (acc.provider.lower(), acc.name.lower()))
+
+    # Depolanan hesapları sözlük yapısına dönüştüren araç metot.
+    def to_dict(self) -> Dict[str, Dict[str, Dict[str, object]]]:
+        """Kayıtlı hesapları kalıcı depolama için serileştirir."""
+
+        exported: Dict[str, Dict[str, Dict[str, object]]] = {}
+        for account in self._accounts.values():
+            exported.setdefault(account.provider, {})[account.name] = {
+                "metadata": dict(account.metadata),
+                "tags": list(account.tags),
+            }
+        return exported
+
+    # Sözlükten kayıt defteri oluşturan sınıf metodu.
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Mapping[str, Mapping[str, object]]]) -> "AccountRegistry":
+        """Serileştirilmiş sözlük yapısından yeni kayıt defteri oluşturur."""
+
+        accounts: List[LinkedAccount] = []
+        for provider, entries in data.items():
+            for name, definition in entries.items():
+                metadata = definition.get("metadata") or {}
+                tags = definition.get("tags") or []
+                accounts.append(
+                    LinkedAccount(
+                        provider=provider,
+                        name=name,
+                        metadata=dict(metadata),
+                        tags=tuple(tags),
+                    )
+                )
+        return cls(accounts)
+
+    # İç anahtar üretimi için kullanılan yardımcı fonksiyon.
+    @staticmethod
+    def _normalise_key(provider: str, name: str) -> Tuple[str, str]:
+        """Hesapları provider ve isim bazında anahtarlamak için standartlaştırma uygular."""
+
+        return provider.lower(), name.lower()
+
+    # İç tutarlılığı kontrol eden yardımcı metot.
+    def _ensure_exists(self, key: Tuple[str, str]) -> LinkedAccount:
+        """Verilen anahtarın kayıtlı olduğundan emin olur, aksi durumda hata döndürür."""
+
+        if key not in self._accounts:
+            provider, name = key
+            raise AccountRegistryError(
+                f"{provider!r} sağlayıcısı için {name!r} hesabı bulunamadı."
+            )
+        return self._accounts[key]

--- a/app_lab_agent/automation.py
+++ b/app_lab_agent/automation.py
@@ -1,0 +1,126 @@
+"""App Lab Agent platformu için otomasyon akışlarını yöneten yardımcılar."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Mapping, Optional
+
+from .accounts import AccountRegistry, LinkedAccount
+
+
+# Otomasyonlarda meydana gelen doğrulama sorunlarını temsil eden hata sınıfı.
+class AutomationValidationError(RuntimeError):
+    """Otomasyon tariflerinde tutarsızlık olduğunda yükseltilen hata."""
+
+
+# n8n veya benzeri araçlarda kullanılmak üzere tanımlanan otomasyon tarifini modelleyen veri sınıfı.
+@dataclass
+class AutomationRecipe:
+    """Bir otomasyonun tetikleyicisini, aksiyonlarını ve ihtiyaç duyduğu hesapları saklar."""
+
+    name: str
+    trigger: str
+    actions: List[str]
+    required_accounts: List[str] = field(default_factory=list)
+    description: Optional[str] = None
+
+    # Otomasyon planını n8n benzeri araçların beklediği forma dönüştüren fonksiyon.
+    def to_n8n_payload(self) -> Mapping[str, object]:
+        """n8n API'lerinin bekleyebileceği basit bir JSON şemasına dönüştürür."""
+
+        return {
+            "name": self.name,
+            "trigger": self.trigger,
+            "actions": list(self.actions),
+            "accounts": list(self.required_accounts),
+            "description": self.description,
+        }
+
+
+# Otomasyon tariflerini kaydeden ve doğrulayan stüdyo sınıfı.
+class AutomationStudio:
+    """Otomasyon tarifleri üzerinde doğrulama ve raporlama yapan yönetici."""
+
+    def __init__(self, account_registry: Optional[AccountRegistry] = None) -> None:
+        self._recipes: Dict[str, AutomationRecipe] = {}
+        self._accounts = account_registry or AccountRegistry()
+
+    # Yeni otomasyon tarifi oluşturan metot.
+    def create_recipe(
+        self,
+        name: str,
+        trigger: str,
+        actions: Iterable[str],
+        required_accounts: Optional[Iterable[str]] = None,
+        description: Optional[str] = None,
+    ) -> AutomationRecipe:
+        """Tarifi oluşturup kayıt altına alır; aynı isim varsa hata verir."""
+
+        key = name.lower()
+        if key in self._recipes:
+            raise AutomationValidationError(f"{name!r} adına sahip otomasyon zaten kayıtlı.")
+
+        recipe = AutomationRecipe(
+            name=name,
+            trigger=trigger,
+            actions=list(actions),
+            required_accounts=list(required_accounts or []),
+            description=description,
+        )
+        self._recipes[key] = recipe
+        return recipe
+
+    # Otomasyonu güncelleyip gerekli hesapları değiştiren metot.
+    def update_required_accounts(self, name: str, accounts: Iterable[str]) -> AutomationRecipe:
+        """Otomasyonun ihtiyaç duyduğu hesap listesini değiştirir."""
+
+        recipe = self._get(name)
+        recipe.required_accounts = list(accounts)
+        return recipe
+
+    # Otomasyonların ihtiyaç duyduğu hesapların kayıtlı olduğundan emin olan doğrulama metodu.
+    def validate_accounts(self, name: str) -> List[LinkedAccount]:
+        """Tarifin talep ettiği tüm hesapların kayıtlı olduğunu doğrular."""
+
+        recipe = self._get(name)
+        linked: List[LinkedAccount] = []
+        missing: List[str] = []
+        for account_name in recipe.required_accounts:
+            provider, _, name_fragment = account_name.partition(":")
+            lookup_provider = provider or account_name
+            lookup_name = name_fragment or account_name
+            try:
+                account = self._accounts.get(lookup_provider, lookup_name)
+            except Exception:  # pragma: no cover - hata mesajını özelleştiriyoruz.
+                missing.append(account_name)
+            else:
+                linked.append(account)
+        if missing:
+            raise AutomationValidationError(
+                "Eksik hesaplar bulundu: " + ", ".join(sorted(missing))
+            )
+        return linked
+
+    # Kayıtlı otomasyonları listeleyen metot.
+    def list_recipes(self) -> List[AutomationRecipe]:
+        """Tüm otomasyon tariflerini alfabetik sırada döndürür."""
+
+        return [self._recipes[key] for key in sorted(self._recipes)]
+
+    # Otomasyonun n8n'e aktarılmaya hazır özetini döndüren metot.
+    def export_recipe(self, name: str) -> Mapping[str, object]:
+        """Tarifi doğrulayarak n8n uyumlu çıktı üretir."""
+
+        recipe = self._get(name)
+        self.validate_accounts(name)
+        return recipe.to_n8n_payload()
+
+    # İç kullanım için tarif arayan fonksiyon.
+    def _get(self, name: str) -> AutomationRecipe:
+        """Verilen isimdeki tarifi getirir, yoksa hata oluşturur."""
+
+        key = name.lower()
+        try:
+            return self._recipes[key]
+        except KeyError as exc:
+            raise AutomationValidationError(f"{name!r} isimli otomasyon bulunamadı.") from exc

--- a/app_lab_agent/navigation.py
+++ b/app_lab_agent/navigation.py
@@ -1,0 +1,152 @@
+"""Frontend menülerini modellemek ve doğrulamak için yardımcı bileşenler."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Mapping, Optional
+
+
+# Menü operasyonlarında karşılaşılabilecek tutarsızlıkları temsil eden hata sınıfı.
+class NavigationMenuError(ValueError):
+    """Menü oluşturma veya güncelleme süreçlerinde oluşan hataları ifade eder."""
+
+
+# Frontend menüsünde gösterilecek tekil öğeyi temsil eden veri sınıfı.
+@dataclass
+class MenuItem:
+    """Menü etiketini, rotasını ve isteğe bağlı rozet bilgisini saklar."""
+
+    key: str
+    label: str
+    route: str
+    description: str = ""
+    badge: Optional[str] = None
+
+    # Menü öğesini JSON uyumlu sözlüğe dönüştüren yardımcı metot.
+    def to_dict(self) -> Mapping[str, object]:
+        """Menü öğesini frontend katmanında kullanılacak sözlük formatına çevirir."""
+
+        exported: Dict[str, object] = {
+            "key": self.key,
+            "label": self.label,
+            "route": self.route,
+            "description": self.description,
+        }
+        if self.badge is not None:
+            exported["badge"] = self.badge
+        return exported
+
+
+# Menü bölümlerini gruplayarak daha iyi gezinme deneyimi sağlayan veri sınıfı.
+@dataclass
+class MenuSection:
+    """Menüde bir başlık altında listelenecek öğeleri ve açıklamayı taşır."""
+
+    identifier: str
+    title: str
+    description: str = ""
+    items: List[MenuItem] = field(default_factory=list)
+
+    # Bölüme yeni menü öğesi ekleyen yardımcı metot.
+    def add_item(self, item: MenuItem) -> None:
+        """Menü öğesini bölüme ekler, aynı anahtar varsa hata üretir."""
+
+        if any(existing.key == item.key for existing in self.items):
+            raise NavigationMenuError(
+                f"{item.key!r} anahtarına sahip menü öğesi zaten mevcut."
+            )
+        self.items.append(item)
+
+    # Bölümde öğe olup olmadığını kolayca kontrol eden özellik.
+    def is_empty(self) -> bool:
+        """Bölümün içerisinde gösterilecek öğe kalmadığını bildirir."""
+
+        return not self.items
+
+    # Bölümü JSON uyumlu sözlüğe dönüştüren yardımcı metot.
+    def to_dict(self) -> Mapping[str, object]:
+        """Frontend katmanına gönderilecek bölüm bilgisini sözlük olarak döndürür."""
+
+        return {
+            "identifier": self.identifier,
+            "title": self.title,
+            "description": self.description,
+            "items": [item.to_dict() for item in self.items],
+        }
+
+
+# Menüyü oluşturan, yeni bölümler ekleyen ve durumunu denetleyen ana sınıf.
+class NavigationMenu:
+    """Menüyü bölümler halinde yöneten ve boş alanları raporlayan yardımcı."""
+
+    def __init__(self, sections: Optional[Iterable[MenuSection]] = None) -> None:
+        self._sections: List[MenuSection] = []
+        if sections:
+            for section in sections:
+                self.add_section(section)
+
+    # Yeni bölüm eklemek için kullanılan yardımcı metot.
+    def add_section(self, section: MenuSection) -> MenuSection:
+        """Menüye yeni bir bölüm ekler, aynı kimlik varsa mevcut olanı döndürür."""
+
+        existing = self.find_section(section.identifier)
+        if existing is not None:
+            return existing
+        self._sections.append(section)
+        return section
+
+    # Kimliği verilen bölümü bulan yardımcı metot.
+    def find_section(self, identifier: str) -> Optional[MenuSection]:
+        """Belirtilen kimliğe sahip menü bölümünü döndürür."""
+
+        for section in self._sections:
+            if section.identifier == identifier:
+                return section
+        return None
+
+    # Bölümün mevcut olduğundan emin olup yoksa oluşturan kolaylaştırıcı metot.
+    def ensure_section(self, identifier: str, title: str, description: str = "") -> MenuSection:
+        """Verilen kimlikte bölüm varsa döndürür, yoksa yeni bölüm oluşturup ekler."""
+
+        existing = self.find_section(identifier)
+        if existing is not None:
+            if description and not existing.description:
+                existing.description = description
+            return existing
+        section = MenuSection(identifier=identifier, title=title, description=description)
+        self._sections.append(section)
+        return section
+
+    # Menünün mevcut durumunu sözlükler listesi olarak döndüren metot.
+    def to_dict(self) -> List[Mapping[str, object]]:
+        """Menü bölümlerini sırayla JSON uyumlu sözlükler listesi olarak döndürür."""
+
+        return [section.to_dict() for section in self._sections]
+
+    # Menüyü zorunlu bölümlere göre denetleyip eksik ve boş alanları raporlayan metot.
+    def audit(self, required_sections: Optional[Iterable[str]] = None) -> Mapping[str, object]:
+        """Menüde eksik veya boş kalan bölümleri raporlayarak frontend kontrollerini kolaylaştırır."""
+
+        exported = self.to_dict()
+        existing_identifiers = {section["identifier"] for section in exported}
+        missing: List[str] = []
+        if required_sections:
+            for identifier in required_sections:
+                if identifier not in existing_identifiers:
+                    missing.append(identifier)
+
+        empty = [section["identifier"] for section in exported if not section["items"]]
+        return {
+            "sections": exported,
+            "missing_sections": missing,
+            "empty_sections": empty,
+        }
+
+
+# Menü rotalarını oluştururken kullanılan küçük yardımcı fonksiyon.
+def slugify(value: str) -> str:
+    """Menü rotalarında kullanılmak üzere basit bir slug üretir."""
+
+    cleaned = value.strip().lower()
+    words = [chunk for chunk in cleaned.replace("_", " ").split() if chunk]
+    return "-".join(words)

--- a/app_lab_agent/platform.py
+++ b/app_lab_agent/platform.py
@@ -1,0 +1,416 @@
+"""App Lab Agent platformunun üst düzey orkestrasyon bileşeni."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, List, Mapping, Optional
+
+from .accounts import AccountRegistry, AccountRegistryError, LinkedAccount
+from .automation import AutomationRecipe, AutomationStudio
+from .projects import Milestone, ProjectBlueprint, ProjectWorkspace
+from .tasks import Task
+from .navigation import MenuItem, NavigationMenu, slugify
+
+
+# Platform seviyesindeki işlemler sırasında oluşabilecek hata türü.
+class AppLabAgentError(RuntimeError):
+    """Platform bileşenleri arasında koordinasyon yapılırken meydana gelen hatalar."""
+
+
+# Tüm bileşenleri bir araya getirerek akıcı API sunan ana sınıf.
+class AppLabAgentPlatform:
+    """Hesap, proje ve otomasyon yönetimini tek noktadan yöneten yardımcı."""
+
+    def __init__(self) -> None:
+        self.accounts = AccountRegistry()
+        self.workspace = ProjectWorkspace(self.accounts)
+        self.automation_studio = AutomationStudio(self.accounts)
+
+    # Platforma yeni hesap eklemeyi kolaylaştıran sarmalayıcı metot.
+    def link_account(
+        self,
+        provider: str,
+        name: str,
+        metadata: Optional[Mapping[str, str]] = None,
+        tags: Optional[Iterable[str]] = None,
+    ) -> LinkedAccount:
+        """Harici servis hesabını platforma kaydedip döndürür."""
+
+        return self.accounts.register(provider, name, metadata=metadata, tags=tags)
+
+    # Yeni proje ve görev panosu oluşturmak için kullanılan metot.
+    def create_project(
+        self,
+        name: str,
+        description: str,
+        tech_stack: Iterable[str],
+        goals: Optional[Iterable[str]] = None,
+        tasks: Optional[Iterable[Mapping[str, str]]] = None,
+    ) -> ProjectBlueprint:
+        """Proje oluşturur, istenirse başlangıç görevlerini de ekler."""
+
+        project = self.workspace.create_project(name, description, tech_stack, goals)
+        if tasks:
+            for task_definition in tasks:
+                identifier = task_definition["identifier"]
+                title = task_definition["title"]
+                description_text = task_definition.get("description", "")
+                owner = task_definition.get("owner")
+                project.task_board.add_task(
+                    Task(
+                        identifier=identifier,
+                        title=title,
+                        description=description_text,
+                        owner=owner,
+                    )
+                )
+        return project
+
+    # Ön izleme uç noktalarında proje çalışma alanını döndüren yardımcı metot.
+    def project_workspace(self, name: str) -> ProjectBlueprint:
+        """Projeyi blueprint halinde döndürerek görev panosuna erişim sağlar."""
+
+        return self.workspace.project_workspace(name)
+
+    # Otomasyon tariflerini oluşturmayı kolaylaştıran sarmalayıcı metot.
+    def create_automation(
+        self,
+        name: str,
+        trigger: str,
+        actions: Iterable[str],
+        required_accounts: Optional[Iterable[str]] = None,
+        description: Optional[str] = None,
+    ) -> AutomationRecipe:
+        """Yeni otomasyon tarifini kaydedip döndürür."""
+
+        return self.automation_studio.create_recipe(
+            name=name,
+            trigger=trigger,
+            actions=actions,
+            required_accounts=required_accounts,
+            description=description,
+        )
+
+    # Proje görevlerini ilerletmek için kullanılan kısayol metotları.
+    def start_project_task(
+        self, project_name: str, identifier: str, owner: Optional[str] = None
+    ) -> Task:
+        """Belirtilen projedeki görevi başlatır ve isteğe bağlı sorumlu atar."""
+
+        return self.workspace.start_task(project_name, identifier, owner)
+
+    def complete_project_task(self, project_name: str, identifier: str) -> Task:
+        """Projeye ait görevi tamamlandı olarak işaretler."""
+
+        return self.workspace.complete_task(project_name, identifier)
+
+    def block_project_task(self, project_name: str, identifier: str, reason: str) -> Task:
+        """Projeye ait görevi bloklayıp açıklama notunu ekler."""
+
+        return self.workspace.block_task(project_name, identifier, reason)
+
+    # Belirli sorumluya atanan görevleri raporlayan metot.
+    def list_tasks_for_owner(
+        self, owner: str, include_unassigned: bool = False
+    ) -> List[Mapping[str, object]]:
+        """Çalışma alanındaki projelerden belirtilen sorumluya ait görevleri döndürür."""
+
+        return self.workspace.tasks_for_owner(owner, include_unassigned=include_unassigned)
+
+    # Platform çapında sorumluların iş yükünü raporlayan sarmalayıcı metot.
+    def owner_workload_report(
+        self, include_unassigned: bool = False
+    ) -> List[Mapping[str, object]]:
+        """Görev yükünü sorumlu bazında toplayıp platform düzeyinde döndürür."""
+
+        return self.workspace.owner_workload(include_unassigned=include_unassigned)
+
+    # Proje kilometre taşlarını yönetmek için sarmalayıcı metotlar.
+    def add_project_milestone(
+        self,
+        project_name: str,
+        title: str,
+        description: str = "",
+        due_date: Optional[str] = None,
+    ) -> Milestone:
+        """Projeye yeni kilometre taşı ekler ve sonucu döndürür."""
+
+        return self.workspace.add_milestone(
+            project_name, title, description=description, due_date=due_date
+        )
+
+    def complete_project_milestone(self, project_name: str, title: str) -> Milestone:
+        """Projeye ait kilometre taşını tamamlandı olarak işaretler."""
+
+        return self.workspace.complete_milestone(project_name, title)
+
+    def upcoming_project_milestones(
+        self, limit: Optional[int] = None, include_completed: bool = False
+    ) -> List[Mapping[str, object]]:
+        """Platform genelindeki kilometre taşlarını yaklaşan tarihe göre listeler."""
+
+        return self.workspace.upcoming_milestones(
+            limit=limit, include_completed=include_completed
+        )
+
+    # Proje kilometre taşlarının gecikme durumlarını raporlayan metot.
+    def overdue_project_milestones(
+        self,
+        reference_date: Optional[str] = None,
+        include_completed: bool = False,
+    ) -> List[Mapping[str, object]]:
+        """Teslim tarihi geçmiş kilometre taşlarını platform genelinde listeler."""
+
+        return self.workspace.overdue_milestones(
+            reference_date=reference_date, include_completed=include_completed
+        )
+
+    # Frontend menü yapısını oluşturan ve eksikleri raporlayan metot.
+    def navigation_menu(self) -> Mapping[str, object]:
+        """Platformdaki kaynaklara hızlı erişim sağlayan menü özetini döndürür."""
+
+        menu = NavigationMenu()
+
+        projects = self.workspace.list_projects()
+        accounts = self.accounts.list_accounts()
+        automations = self.automation_studio.list_recipes()
+
+        overview_section = menu.ensure_section(
+            "overview",
+            "Genel Bakış",
+            "Önemli raporlar ve portföy istatistikleri için başlangıç noktası.",
+        )
+        overview_section.add_item(
+            MenuItem(
+                key="portfolio",
+                label="Portföy Özeti",
+                route="/portfolio",
+                description="Projeleri, hesapları ve otomasyonları tek ekranda toplar.",
+                badge=str(len(projects)),
+            )
+        )
+
+        accounts_section = menu.ensure_section(
+            "accounts",
+            "Hesaplar",
+            "Bağlanan servis hesaplarını ve meta verilerini listeler.",
+        )
+        for account in accounts:
+            metadata_summary = ", ".join(
+                f"{key}: {value}" for key, value in sorted(account.metadata.items())
+            )
+            description = metadata_summary or "Bu hesap için meta veri tanımlanmadı."
+            badge = f"{len(account.tags)} etiket" if account.tags else None
+            accounts_section.add_item(
+                MenuItem(
+                    key=f"{account.provider}:{account.name}",
+                    label=f"{account.provider.title()} · {account.name}",
+                    route=f"/accounts/{account.provider}/{account.name}",
+                    description=description,
+                    badge=badge,
+                )
+            )
+
+        projects_section = menu.ensure_section(
+            "projects",
+            "Projeler",
+            "Aktif projeleri açıklamaları ve ilerleme oranıyla gösterir.",
+        )
+        for project in projects:
+            progress = project.task_board.progress_report()
+            badge = f"{progress['done']}/{progress['total']}" if progress["total"] else "0/0"
+            projects_section.add_item(
+                MenuItem(
+                    key=project.name,
+                    label=project.name,
+                    route=f"/projects/{slugify(project.name)}",
+                    description=project.description or "Bu proje için açıklama girilmedi.",
+                    badge=badge,
+                )
+            )
+
+        automations_section = menu.ensure_section(
+            "automations",
+            "Otomasyonlar",
+            "Çalışma alanındaki otomasyon tariflerini ve tetikleyicilerini listeler.",
+        )
+        for recipe in automations:
+            description = recipe.description or f"Tetikleyici: {recipe.trigger}"
+            badge = f"{len(recipe.actions)} adım"
+            automations_section.add_item(
+                MenuItem(
+                    key=recipe.name,
+                    label=recipe.name,
+                    route=f"/automations/{slugify(recipe.name)}",
+                    description=description,
+                    badge=badge,
+                )
+            )
+
+        return menu.audit(
+            required_sections=("overview", "accounts", "projects", "automations")
+        )
+
+    # Proje ve otomasyon bilgilerini derleyen raporlama metodu.
+    def portfolio_overview(self) -> Mapping[str, object]:
+        """Platformdaki projeler, hesaplar ve otomasyonlara dair özet çıkarır."""
+
+        projects = [project.summary() for project in self.workspace.list_projects()]
+        accounts = [account for account in self.accounts.list_accounts()]
+        automations = [recipe.to_n8n_payload() for recipe in self.automation_studio.list_recipes()]
+        return {
+            "projects": projects,
+            "accounts": [
+                {
+                    "provider": account.provider,
+                    "name": account.name,
+                    "metadata": dict(account.metadata),
+                    "tags": list(account.tags),
+                }
+                for account in accounts
+            ],
+            "automations": automations,
+        }
+
+    # Bir projenin ihtiyaç duyduğu hesapların bağlanıp bağlanmadığını kontrol eden fonksiyon.
+    def ensure_project_has_accounts(self, project_name: str, providers: Iterable[str]) -> None:
+        """Projeye gerekli sağlayıcıların bağlandığından emin olur, eksik varsa hata atar."""
+
+        project = self.workspace._get_project(project_name)
+        missing = []
+        for provider in providers:
+            if not any(acc.provider.lower() == provider.lower() for acc in project.linked_accounts):
+                missing.append(provider)
+        if missing:
+            raise AppLabAgentError(
+                f"{project_name!r} projesinde eksik sağlayıcılar: {', '.join(missing)}"
+            )
+
+    # Proje ile otomasyonu ilişkilendirip görev atayan metot.
+    def assign_automation_to_project(self, project_name: str, automation_name: str) -> Mapping[str, object]:
+        """Projeye otomasyon bağlar, gerekli hesaplar yoksa hata üretir."""
+
+        project = self.workspace._get_project(project_name)
+        recipe = self.automation_studio._get(automation_name)
+        self.automation_studio.validate_accounts(automation_name)
+        for required in recipe.required_accounts:
+            provider, _, name_fragment = required.partition(":")
+            lookup_provider = provider or required
+            lookup_name = name_fragment or required
+            account = self.accounts.get(lookup_provider, lookup_name)
+            if account not in project.linked_accounts:
+                project.linked_accounts.append(account)
+        if recipe.name not in project.automations:
+            project.automations.append(recipe.name)
+        # Otomasyonun devreye alınması için takip görevini oluşturuyoruz.
+        automation_task = Task(
+            identifier=f"automation::{recipe.name}",
+            title=f"Otomasyon devreye alma - {recipe.name}",
+            description=f"{recipe.trigger} tetikleyicili otomasyonu üretim ortamına taşı.",
+        )
+        try:
+            project.task_board.add_task(automation_task)
+        except ValueError:
+            # Görev daha önce eklenmişse tekrar eklemeye gerek yok.
+            pass
+        return {
+            "project": project.summary(),
+            "automation": recipe.to_n8n_payload(),
+        }
+
+    # Platformdaki tüm verileri basit sözlük olarak dışa aktaran metot.
+    def export_state(self) -> Mapping[str, object]:
+        """Platform durumunu kolay yedeklenebilir sözlük formatında döndürür."""
+
+        return {
+            "accounts": self.accounts.to_dict(),
+            "projects": [project.summary() for project in self.workspace.list_projects()],
+            "automations": [recipe.to_n8n_payload() for recipe in self.automation_studio.list_recipes()],
+        }
+
+    # Proje teknoloji yığınları ile hesap/otomasyon entegrasyonlarını denetleyen rapor.
+    def integration_audit(self) -> List[Mapping[str, object]]:
+        """Teknoloji yığınlarına göre eksik hesap veya otomasyon bağlantılarını raporlar."""
+
+        audit: List[Mapping[str, object]] = []
+        automation_index: Dict[str, AutomationRecipe] = {
+            recipe.name.lower(): recipe for recipe in self.automation_studio.list_recipes()
+        }
+        for project in self.workspace.list_projects():
+            tech_stack = [entry.strip() for entry in project.tech_stack if entry.strip()]
+            missing_accounts: List[str] = []
+            tech_coverage: Dict[str, List[Mapping[str, object]]] = {}
+            for tech in tech_stack:
+                normalized = tech.lower()
+                matches: List[Mapping[str, object]] = []
+                for account in project.linked_accounts:
+                    tags = {tag.lower() for tag in account.tags}
+                    if account.provider.lower() == normalized or normalized in tags:
+                        matches.append(
+                            {
+                                "provider": account.provider,
+                                "name": account.name,
+                                "metadata": dict(account.metadata),
+                                "tags": list(account.tags),
+                            }
+                        )
+                if matches:
+                    tech_coverage[tech] = matches
+                else:
+                    missing_accounts.append(tech)
+
+            automation_gaps: List[Mapping[str, object]] = []
+            for automation_name in project.automations:
+                recipe = automation_index.get(automation_name.lower())
+                if not recipe:
+                    automation_gaps.append(
+                        {
+                            "automation": automation_name,
+                            "missing_accounts": [
+                                "KAYITSIZ-OTOMASYON"
+                            ],
+                        }
+                    )
+                    continue
+                missing_for_recipe: List[str] = []
+                for required in recipe.required_accounts:
+                    provider, _, name_fragment = required.partition(":")
+                    lookup_provider = provider or required
+                    lookup_name = name_fragment or required
+                    try:
+                        account = self.accounts.get(lookup_provider, lookup_name)
+                    except AccountRegistryError:
+                        missing_for_recipe.append(required)
+                        continue
+                    if account not in project.linked_accounts:
+                        missing_for_recipe.append(f"{required} (proje bağlantısı yok)")
+                if missing_for_recipe:
+                    automation_gaps.append(
+                        {
+                            "automation": recipe.name,
+                            "missing_accounts": missing_for_recipe,
+                        }
+                    )
+
+            audit.append(
+                {
+                    "project": project.name,
+                    "tech_stack": tech_stack,
+                    "linked_accounts": [
+                        {
+                            "provider": account.provider,
+                            "name": account.name,
+                            "metadata": dict(account.metadata),
+                            "tags": list(account.tags),
+                        }
+                        for account in project.linked_accounts
+                    ],
+                    "automations": list(project.automations),
+                    "tech_coverage": tech_coverage,
+                    "missing_account_integrations": missing_accounts,
+                    "automation_gaps": automation_gaps,
+                    "status": "ok"
+                    if not missing_accounts and not automation_gaps
+                    else "needs_attention",
+                }
+            )
+        return audit

--- a/app_lab_agent/projects.py
+++ b/app_lab_agent/projects.py
@@ -1,0 +1,469 @@
+"""App Lab Agent projelerini planlamaya ve yönetmeye odaklı bileşenler."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, date
+from enum import Enum
+from typing import Dict, Iterable, List, Mapping, Optional
+
+from .accounts import AccountRegistry, LinkedAccount
+from .tasks import Task, TaskBoard, TaskStatus
+
+
+# Proje çalışma alanlarında kullanılan hata türü.
+class ProjectWorkspaceError(RuntimeError):
+    """Projeler üzerinde çalışırken oluşan hataları temsil eder."""
+
+
+# Proje düzeyindeki özet bilgiyi taşıyan veri sınıfı.
+@dataclass
+class ProjectBlueprint:
+    """Bir projenin temel yapı taşlarını ve referanslarını saklar."""
+
+    name: str
+    description: str
+    tech_stack: List[str]
+    goals: List[str]
+    task_board: TaskBoard = field(default_factory=TaskBoard)
+    linked_accounts: List[LinkedAccount] = field(default_factory=list)
+    milestones: List["Milestone"] = field(default_factory=list)
+    # Projenin bağlı otomasyon adlarını saklayan liste.
+    automations: List[str] = field(default_factory=list)
+
+    # UI ön izlemelerinde görev panosuna ulaşmayı kolaylaştıran özellik.
+    @property
+    def board(self) -> TaskBoard:
+        """Görev panosu referansını frontendlere aktarır."""
+
+        return self.task_board
+
+    # Proje için kısa özet çıkaran yardımcı fonksiyon.
+    def summary(self) -> Mapping[str, object]:
+        """Projeye ait temel istatistikleri sözlük formatında döndürür."""
+
+        progress = self.task_board.progress_report()
+        progress["tasks"] = [
+            {
+                "identifier": task.identifier,
+                "title": task.title,
+                "status": task.status.value,
+                "owner": task.owner,
+            }
+            for task in self.task_board.list_by_status()
+        ]
+        progress["milestones"] = [milestone.to_summary() for milestone in self.milestones]
+        progress["automations"] = list(self.automations)
+        return {
+            "name": self.name,
+            "description": self.description,
+            "tech_stack": list(self.tech_stack),
+            "goals": list(self.goals),
+            "linked_accounts": [account.name for account in self.linked_accounts],
+            "automations": list(self.automations),
+            "progress": progress,
+        }
+
+    # Projeye yeni hedef eklemeyi sağlayan yardımcı metot.
+    def add_goal(self, goal: str) -> None:
+        """Proje hedefleri listesine yeni hedef ekler."""
+
+        if goal not in self.goals:
+            self.goals.append(goal)
+
+    # Proje yol haritasında kullanılan kilometre taşlarını saklayan yardımcı metot.
+    def add_milestone(self, milestone: "Milestone") -> None:
+        """Yeni kilometre taşını proje kaydına ekler."""
+
+        if any(existing.title == milestone.title for existing in self.milestones):
+            raise ProjectWorkspaceError(
+                f"{milestone.title!r} adlı kilometre taşı zaten mevcut."
+            )
+        self.milestones.append(milestone)
+
+    # Proje içindeki kilometre taşlarını durum bazlı arayan metot.
+    def list_milestones(self, status: Optional["MilestoneStatus"] = None) -> List["Milestone"]:
+        """Kilometre taşlarını filtreleyerek döndürür."""
+
+        if status is None:
+            return list(self.milestones)
+        return [milestone for milestone in self.milestones if milestone.status == status]
+
+    # Projede belirli bir kilometre taşını bulan yardımcı metot.
+    def get_milestone(self, title: str) -> "Milestone":
+        """Başlığa göre kilometre taşını bulur, yoksa hata üretir."""
+
+        for milestone in self.milestones:
+            if milestone.title == title:
+                return milestone
+        raise ProjectWorkspaceError(f"{title!r} başlıklı kilometre taşı bulunamadı.")
+
+
+# Birden fazla projeyi organize eden çalışma alanı sınıfı.
+class ProjectWorkspace:
+    """Projeleri oluşturan, yöneten ve raporlayan ana konteyner."""
+
+    def __init__(self, account_registry: Optional[AccountRegistry] = None) -> None:
+        self._projects: Dict[str, ProjectBlueprint] = {}
+        self._accounts = account_registry or AccountRegistry()
+
+    # Yeni proje oluşturan ana yardımcı metot.
+    def create_project(
+        self,
+        name: str,
+        description: str,
+        tech_stack: Iterable[str],
+        goals: Optional[Iterable[str]] = None,
+    ) -> ProjectBlueprint:
+        """Yeni proje oluşturur ve çalışma alanına ekler."""
+
+        slug = self._slugify(name)
+        if slug in self._projects:
+            raise ProjectWorkspaceError(f"{name!r} adına sahip proje zaten var.")
+
+        project = ProjectBlueprint(
+            name=name,
+            description=description,
+            tech_stack=list(tech_stack),
+            goals=list(goals or []),
+        )
+        self._projects[slug] = project
+        return project
+
+    # Proje silmeyi sağlayan yardımcı metot.
+    def delete_project(self, name: str) -> ProjectBlueprint:
+        """Projeyi isim üzerinden kaldırır ve kaldırılan örneği döndürür."""
+
+        slug = self._slugify(name)
+        try:
+            return self._projects.pop(slug)
+        except KeyError as exc:
+            raise ProjectWorkspaceError(f"{name!r} isimli proje bulunamadı.") from exc
+
+    # Çalışma alanındaki projeleri listeleyen metot.
+    def list_projects(self) -> List[ProjectBlueprint]:
+        """Tüm projeleri oluşturulma sırasına göre döndürür."""
+
+        return list(self._projects.values())
+
+    # Ön izleme ve servis katmanları için proje kaydını döndüren yardımcı metot.
+    def project_workspace(self, name: str) -> ProjectBlueprint:
+        """Projeye ait blueprint'i doğrudan erişim için döndürür."""
+
+        return self._get_project(name)
+
+    # Projeye görev ekleme sürecini kolaylaştıran metot.
+    def add_task_to_project(
+        self,
+        project_name: str,
+        identifier: str,
+        title: str,
+        description: str,
+        owner: Optional[str] = None,
+    ) -> Task:
+        """Belirtilen projeye yeni görev ekler ve görevi döndürür."""
+
+        project = self._get_project(project_name)
+        task = Task(identifier=identifier, title=title, description=description, owner=owner)
+        project.task_board.add_task(task)
+        return task
+
+    # Projedeki görevi başlatıp ilerleme durumunu güncelleyen metot.
+    def start_task(self, project_name: str, identifier: str, owner: Optional[str] = None) -> Task:
+        """Görevi 'in_progress' durumuna çeker ve isteğe göre sorumlu atar."""
+
+        project = self._get_project(project_name)
+        return project.task_board.mark_in_progress(identifier, owner)
+
+    # Projede tamamlanan görevi işaretleyen metot.
+    def complete_task(self, project_name: str, identifier: str) -> Task:
+        """Görevi 'done' durumuna taşıyarak tamamlandığını kaydeder."""
+
+        project = self._get_project(project_name)
+        return project.task_board.mark_done(identifier)
+
+    # Görevi bloklayıp açıklama ekleyen yardımcı metot.
+    def block_task(self, project_name: str, identifier: str, reason: str) -> Task:
+        """Görevi 'blocked' durumuna getirir ve sebep notunu ekler."""
+
+        project = self._get_project(project_name)
+        return project.task_board.block_task(identifier, reason)
+
+    # Projede kullanılacak hesabı ilişkilendiren yardımcı metot.
+    def link_account_to_project(self, project_name: str, provider: str, account_name: str) -> LinkedAccount:
+        """Kayıtlı bir hesabı projeye bağlar ve referansını döndürür."""
+
+        project = self._get_project(project_name)
+        account = self._accounts.get(provider, account_name)
+        if account not in project.linked_accounts:
+            project.linked_accounts.append(account)
+        return account
+
+    # Projeye yeni kilometre taşı ekleyen yardımcı metot.
+    def add_milestone(
+        self,
+        project_name: str,
+        title: str,
+        description: str = "",
+        due_date: Optional[str] = None,
+    ) -> "Milestone":
+        """Belirtilen projeye kilometre taşı ekler."""
+
+        project = self._get_project(project_name)
+        milestone = Milestone(title=title, description=description, due_date=due_date)
+        project.add_milestone(milestone)
+        return milestone
+
+    # Projedeki kilometre taşını tamamlanmış olarak işaretleyen metot.
+    def complete_milestone(self, project_name: str, title: str) -> "Milestone":
+        """Kilometre taşını tamamlandı durumuna getirir."""
+
+        project = self._get_project(project_name)
+        milestone = project.get_milestone(title)
+        milestone.complete()
+        return milestone
+
+    # Çalışma alanında yaklaşan kilometre taşlarını raporlayan metot.
+    def upcoming_milestones(
+        self, limit: Optional[int] = None, include_completed: bool = False
+    ) -> List[Mapping[str, object]]:
+        """Projelerde yaklaşan kilometre taşlarını son teslim tarihine göre sıralar."""
+
+        collected: List[Mapping[str, object]] = []
+        for project in self._projects.values():
+            for milestone in project.milestones:
+                if not include_completed and milestone.status == MilestoneStatus.COMPLETED:
+                    continue
+                collected.append(
+                    {
+                        "project": project.name,
+                        "milestone": milestone.title,
+                        "due_date": milestone.due_date,
+                        "status": milestone.status.value,
+                    }
+                )
+
+        def _sort_key(entry: Mapping[str, object]) -> tuple:
+            due = entry.get("due_date")
+            if not due:
+                return (datetime.max, entry["project"], entry["milestone"])
+            try:
+                return (datetime.fromisoformat(str(due)), entry["project"], entry["milestone"])
+            except ValueError:
+                return (datetime.max, entry["project"], entry["milestone"])
+
+        collected.sort(key=_sort_key)
+        if limit is not None:
+            return collected[:limit]
+        return collected
+
+    # Teslim tarihi geçmiş kilometre taşlarını raporlayan metot.
+    def overdue_milestones(
+        self,
+        reference_date: Optional[str] = None,
+        include_completed: bool = False,
+    ) -> List[Mapping[str, object]]:
+        """Teslim tarihi referans tarihten önce olan kilometre taşlarını listeler."""
+
+        if reference_date is None:
+            reference = datetime.utcnow().date()
+        else:
+            try:
+                reference = datetime.fromisoformat(reference_date).date()
+            except ValueError as exc:
+                raise ProjectWorkspaceError(
+                    "Referans tarihi ISO formatında olmalıdır."
+                ) from exc
+
+        overdue_entries: List[tuple[date, Mapping[str, object]]] = []
+        for project in self._projects.values():
+            for milestone in project.milestones:
+                if not include_completed and milestone.status == MilestoneStatus.COMPLETED:
+                    continue
+                if milestone.due_date is None:
+                    continue
+                try:
+                    due_date_value = datetime.fromisoformat(milestone.due_date).date()
+                except ValueError:
+                    # Geçersiz tarihler raporlanmaz.
+                    continue
+                if due_date_value >= reference:
+                    continue
+                overdue_entries.append(
+                    (
+                        due_date_value,
+                        {
+                            "project": project.name,
+                            "milestone": milestone.title,
+                            "due_date": milestone.due_date,
+                            "status": milestone.status.value,
+                        },
+                    )
+                )
+
+        overdue_entries.sort(key=lambda entry: (entry[0], entry[1]["project"], entry[1]["milestone"]))
+        return [entry[1] for entry in overdue_entries]
+
+    # Belirli sağlayıcıya ihtiyaç duyan projeleri filtreleyen metot.
+    def find_projects_needing_account(self, provider: str) -> List[ProjectBlueprint]:
+        """Belirtilen sağlayıcıya henüz bağlanmamış projeleri döndürür."""
+
+        provider_key = provider.lower()
+        result = []
+        for project in self._projects.values():
+            if not any(acc.provider.lower() == provider_key for acc in project.linked_accounts):
+                result.append(project)
+        return result
+
+    # Proje ilerlemesini durum bazında özetleyen metot.
+    def status_overview(self) -> Mapping[str, Mapping[str, int]]:
+        """Projelerdeki görev durumlarını toplu olarak raporlar."""
+
+        overview: Dict[str, Dict[str, int]] = {}
+        for project in self._projects.values():
+            counts = {status.value: 0 for status in TaskStatus}
+            for task in project.task_board.list_by_status():
+                counts[task.status.value] += 1
+            overview[project.name] = counts
+        return overview
+
+    # Belirli bir sahibin sorumluluğundaki görevleri proje bazında toplayan metot.
+    def tasks_for_owner(
+        self, owner: str, include_unassigned: bool = False
+    ) -> List[Mapping[str, object]]:
+        """Sorumlu adına göre görevleri sıralayıp proje, durum ve not bilgileriyle döndürür."""
+
+        if not owner or not owner.strip():
+            raise ProjectWorkspaceError("Sorumlu adı boş bırakılamaz.")
+
+        collected: List[Mapping[str, object]] = []
+        for project in self._projects.values():
+            for task in project.task_board.list_by_owner(
+                owner, include_unassigned=include_unassigned
+            ):
+                collected.append(
+                    {
+                        "project": project.name,
+                        "identifier": task.identifier,
+                        "title": task.title,
+                        "status": task.status.value,
+                        "owner": task.owner,
+                        "notes": list(task.notes),
+                    }
+                )
+
+        status_priority = {
+            TaskStatus.BLOCKED.value: 0,
+            TaskStatus.IN_PROGRESS.value: 1,
+            TaskStatus.PENDING.value: 2,
+            TaskStatus.DONE.value: 3,
+        }
+
+        def _sort_key(entry: Mapping[str, object]) -> tuple:
+            return (
+                status_priority.get(entry["status"], 99),
+                entry["project"],
+                entry["identifier"],
+            )
+
+        collected.sort(key=_sort_key)
+        return collected
+
+    # Sorumlu bazlı iş yükünü projeler arasında toplayan yardımcı metot.
+    def owner_workload(
+        self, include_unassigned: bool = False
+    ) -> List[Mapping[str, object]]:
+        """Projelerdeki görev yükünü sorumlu başına toplayıp döndürür."""
+
+        aggregated: Dict[str, Dict[str, object]] = {}
+        for project in self._projects.values():
+            for entry in project.task_board.workload_by_owner(
+                include_unassigned=include_unassigned
+            ):
+                owner_key = entry["normalized_owner"]
+                bucket = aggregated.setdefault(
+                    owner_key,
+                    {
+                        "owner": entry["owner"],
+                        "normalized_owner": owner_key,
+                        "total": 0,
+                        "status_breakdown": {status.value: 0 for status in TaskStatus},
+                        "projects": [],
+                    },
+                )
+
+                if bucket["owner"] is None and entry["owner"] is not None:
+                    bucket["owner"] = entry["owner"]
+
+                bucket["total"] += entry["total"]
+                for status, count in entry["status_breakdown"].items():
+                    bucket["status_breakdown"][status] += count
+
+                bucket["projects"].append(
+                    {
+                        "project": project.name,
+                        "tasks": entry["tasks"],
+                    }
+                )
+
+        return sorted(
+            aggregated.values(),
+            key=lambda item: (
+                -item["total"],
+                1 if item["normalized_owner"] == "__unassigned__" else 0,
+                item["normalized_owner"],
+            ),
+        )
+
+    # Çalışma alanında isimden projeyi bulan yardımcı fonksiyon.
+    def _get_project(self, name: str) -> ProjectBlueprint:
+        """İsme göre projeyi bulur, yoksa hata yükseltir."""
+
+        slug = self._slugify(name)
+        try:
+            return self._projects[slug]
+        except KeyError as exc:
+            raise ProjectWorkspaceError(f"{name!r} adlı proje bulunamadı.") from exc
+
+    # İsimleri slug formatına çeviren yardımcı metot.
+    @staticmethod
+    def _slugify(name: str) -> str:
+        """Projeleri saklamak için kullanılan slug değerini üretir."""
+
+        return "-".join(name.lower().split())
+
+
+# Kilometre taşlarının durumlarını takip etmek için kullanılan enum.
+class MilestoneStatus(str, Enum):
+    """Kilometre taşı durumlarının metin karşılıklarını saklar."""
+
+    PENDING = "pending"
+    COMPLETED = "completed"
+
+
+# Proje yol haritalarında kullanılan kilometre taşı veri sınıfı.
+@dataclass
+class Milestone:
+    """Kilometre taşı detaylarını ve ilerleme durumunu saklar."""
+
+    title: str
+    description: str = ""
+    due_date: Optional[str] = None
+    status: MilestoneStatus = MilestoneStatus.PENDING
+
+    # Kilometre taşını tamamlanmış olarak işaretleyen yardımcı metot.
+    def complete(self) -> None:
+        """Kilometre taşını tamamlandı olarak günceller."""
+
+        self.status = MilestoneStatus.COMPLETED
+
+    # Özet raporlarda kullanılacak sözlük çıktısını döndüren metot.
+    def to_summary(self) -> Mapping[str, object]:
+        """Kilometre taşını raporlamada kullanılacak formata çevirir."""
+
+        return {
+            "title": self.title,
+            "description": self.description,
+            "due_date": self.due_date,
+            "status": self.status.value,
+        }

--- a/app_lab_agent/storage.py
+++ b/app_lab_agent/storage.py
@@ -1,0 +1,452 @@
+"""Platform durumunu serileştirmek ve geri yüklemek için veri şemaları sağlar."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Mapping, Optional
+
+from .accounts import AccountRegistry, LinkedAccount
+from .automation import AutomationRecipe, AutomationStudio, AutomationValidationError
+from .platform import AppLabAgentPlatform
+from .projects import (
+    Milestone,
+    MilestoneStatus,
+    ProjectBlueprint,
+    ProjectWorkspace,
+    ProjectWorkspaceError,
+)
+from .tasks import Task, TaskStatus
+
+
+# Hesap kayıtlarını serileştirmek için kullanılan veri sınıfı.
+@dataclass
+class AccountRecord:
+    """Hesap bilgisini depolamak için kullanılan temel yapı."""
+
+    provider: str
+    name: str
+    metadata: Dict[str, str] = field(default_factory=dict)
+    tags: List[str] = field(default_factory=list)
+
+    # LinkedAccount nesnesinden kayıt üretmeye yarayan yardımcı fonksiyon.
+    @classmethod
+    def from_linked_account(cls, account: LinkedAccount) -> "AccountRecord":
+        """Var olan bağlı hesabı serileştirilmiş kayıt formatına dönüştürür."""
+
+        return cls(
+            provider=account.provider,
+            name=account.name,
+            metadata=dict(account.metadata),
+            tags=list(account.tags),
+        )
+
+    # Kayıttan LinkedAccount nesnesi oluşturan yardımcı fonksiyon.
+    def to_linked_account(self) -> LinkedAccount:
+        """Serileştirilmiş kaydı LinkedAccount nesnesine çevirir."""
+
+        return LinkedAccount(
+            provider=self.provider,
+            name=self.name,
+            metadata=dict(self.metadata),
+            tags=tuple(self.tags),
+        )
+
+    # Sözlük formatında çıktı üreten metot.
+    def to_dict(self) -> Dict[str, object]:
+        """Kayıt bilgisini JSON uyumlu sözlük olarak döndürür."""
+
+        return {
+            "provider": self.provider,
+            "name": self.name,
+            "metadata": dict(self.metadata),
+            "tags": list(self.tags),
+        }
+
+    # Sözlükten kayıt üreten sınıf metodu.
+    @classmethod
+    def from_dict(cls, data: Mapping[str, object]) -> "AccountRecord":
+        """Sözlük bilgisinden kayıt nesnesi oluşturur."""
+
+        return cls(
+            provider=str(data["provider"]),
+            name=str(data["name"]),
+            metadata=dict(data.get("metadata", {})),
+            tags=list(data.get("tags", [])),
+        )
+
+
+# Görev kayıtlarını saklayan veri sınıfı.
+@dataclass
+class TaskRecord:
+    """Görev detaylarını kalıcı formata taşıyan yapı."""
+
+    identifier: str
+    title: str
+    description: str
+    status: str = TaskStatus.PENDING.value
+    owner: Optional[str] = None
+    notes: List[str] = field(default_factory=list)
+
+    # Task nesnesinden kayıt üretmeye yarayan yardımcı fonksiyon.
+    @classmethod
+    def from_task(cls, task: Task) -> "TaskRecord":
+        """Görevi serileştirilebilir kayıt biçimine çevirir."""
+
+        return cls(
+            identifier=task.identifier,
+            title=task.title,
+            description=task.description,
+            status=task.status.value,
+            owner=task.owner,
+            notes=list(task.notes),
+        )
+
+    # Kayıttan Task nesnesi oluşturan yardımcı metot.
+    def to_task(self) -> Task:
+        """Serileştirilmiş görev kaydını Task nesnesine dönüştürür."""
+
+        task = Task(
+            identifier=self.identifier,
+            title=self.title,
+            description=self.description,
+            owner=self.owner,
+        )
+        task.status = TaskStatus(self.status)
+        task.notes = list(self.notes)
+        return task
+
+    # Sözlük formatında çıktı sağlayan metot.
+    def to_dict(self) -> Dict[str, object]:
+        """Görev kaydını JSON uyumlu sözlük olarak döndürür."""
+
+        return {
+            "identifier": self.identifier,
+            "title": self.title,
+            "description": self.description,
+            "status": self.status,
+            "owner": self.owner,
+            "notes": list(self.notes),
+        }
+
+    # Sözlükten kayıt oluşturan sınıf metodu.
+    @classmethod
+    def from_dict(cls, data: Mapping[str, object]) -> "TaskRecord":
+        """Sözlük bilgisinden görev kaydı üretir."""
+
+        return cls(
+            identifier=str(data["identifier"]),
+            title=str(data["title"]),
+            description=str(data.get("description", "")),
+            status=str(data.get("status", TaskStatus.PENDING.value)),
+            owner=data.get("owner"),
+            notes=list(data.get("notes", [])),
+        )
+
+
+# Kilometre taşı kayıtlarını saklayan veri sınıfı.
+@dataclass
+class MilestoneRecord:
+    """Kilometre taşı ayrıntılarını kalıcı formata dönüştüren yapı."""
+
+    title: str
+    description: str = ""
+    due_date: Optional[str] = None
+    status: str = MilestoneStatus.PENDING.value
+
+    # Milestone nesnesinden kayıt üretmeye yarayan yardımcı fonksiyon.
+    @classmethod
+    def from_milestone(cls, milestone: Milestone) -> "MilestoneRecord":
+        """Kilometre taşını serileştirilebilir kayıt formatına çevirir."""
+
+        return cls(
+            title=milestone.title,
+            description=milestone.description,
+            due_date=milestone.due_date,
+            status=milestone.status.value,
+        )
+
+    # Kayıttan Milestone nesnesi oluşturan yardımcı metot.
+    def to_milestone(self) -> Milestone:
+        """Serileştirilmiş kilometre taşını Milestone nesnesine dönüştürür."""
+
+        milestone = Milestone(
+            title=self.title,
+            description=self.description,
+            due_date=self.due_date,
+        )
+        milestone.status = MilestoneStatus(self.status)
+        return milestone
+
+    # Sözlük formatında çıktı sağlayan metot.
+    def to_dict(self) -> Dict[str, object]:
+        """Kilometre taşı kaydını JSON uyumlu sözlük olarak döndürür."""
+
+        return {
+            "title": self.title,
+            "description": self.description,
+            "due_date": self.due_date,
+            "status": self.status,
+        }
+
+    # Sözlükten kayıt oluşturan sınıf metodu.
+    @classmethod
+    def from_dict(cls, data: Mapping[str, object]) -> "MilestoneRecord":
+        """Sözlük bilgisinden kilometre taşı kaydı üretir."""
+
+        return cls(
+            title=str(data["title"]),
+            description=str(data.get("description", "")),
+            due_date=data.get("due_date"),
+            status=str(data.get("status", MilestoneStatus.PENDING.value)),
+        )
+
+
+# Proje kayıtlarını saklayan veri sınıfı.
+@dataclass
+class ProjectRecord:
+    """Projeye ait görev ve hesap referanslarını içeren serileştirme yapısı."""
+
+    name: str
+    description: str
+    tech_stack: List[str] = field(default_factory=list)
+    goals: List[str] = field(default_factory=list)
+    tasks: List[TaskRecord] = field(default_factory=list)
+    linked_accounts: List[str] = field(default_factory=list)
+    milestones: List[MilestoneRecord] = field(default_factory=list)
+    automations: List[str] = field(default_factory=list)
+
+    # ProjectBlueprint nesnesinden kayıt üretir.
+    @classmethod
+    def from_project(cls, project: ProjectBlueprint) -> "ProjectRecord":
+        """Proje çalışma alanındaki blueprint'i serileştirilebilir kayda dönüştürür."""
+
+        tasks = [TaskRecord.from_task(task) for task in project.task_board.list_by_status()]
+        milestones = [MilestoneRecord.from_milestone(item) for item in project.milestones]
+        linked = [f"{account.provider}:{account.name}" for account in project.linked_accounts]
+        return cls(
+            name=project.name,
+            description=project.description,
+            tech_stack=list(project.tech_stack),
+            goals=list(project.goals),
+            tasks=tasks,
+            milestones=milestones,
+            linked_accounts=linked,
+            automations=list(project.automations),
+        )
+
+    # Kayıt bilgisini çalışma alanına uygular.
+    def apply(self, workspace: ProjectWorkspace, registry: AccountRegistry) -> ProjectBlueprint:
+        """Kayıttaki projeyi çalışma alanına yeniden kurar."""
+
+        blueprint = workspace.create_project(
+            name=self.name,
+            description=self.description,
+            tech_stack=self.tech_stack,
+            goals=self.goals,
+        )
+        for task_record in self.tasks:
+            task = task_record.to_task()
+            # Görev kimliği benzersiz olmalı, mevcutsa güncelliyoruz.
+            try:
+                blueprint.task_board.add_task(task)
+            except ValueError:
+                existing = blueprint.task_board.get_task(task.identifier)
+                existing.title = task.title
+                existing.description = task.description
+                existing.status = task.status
+                existing.owner = task.owner
+                existing.notes = list(task.notes)
+        for milestone_record in self.milestones:
+            milestone = milestone_record.to_milestone()
+            try:
+                blueprint.add_milestone(milestone)
+            except ProjectWorkspaceError:
+                existing = blueprint.get_milestone(milestone.title)
+                existing.description = milestone.description
+                existing.due_date = milestone.due_date
+                existing.status = milestone.status
+        for reference in self.linked_accounts:
+            provider, _, name_fragment = reference.partition(":")
+            account = registry.get(provider, name_fragment or provider)
+            if account not in blueprint.linked_accounts:
+                blueprint.linked_accounts.append(account)
+        for automation in self.automations:
+            if automation not in blueprint.automations:
+                blueprint.automations.append(automation)
+        return blueprint
+
+    # Sözlük olarak çıktı üretir.
+    def to_dict(self) -> Dict[str, object]:
+        """Projeyi JSON uyumlu sözlük formatına dönüştürür."""
+
+        return {
+            "name": self.name,
+            "description": self.description,
+            "tech_stack": list(self.tech_stack),
+            "goals": list(self.goals),
+            "tasks": [task.to_dict() for task in self.tasks],
+            "milestones": [milestone.to_dict() for milestone in self.milestones],
+            "linked_accounts": list(self.linked_accounts),
+            "automations": list(self.automations),
+        }
+
+    # Sözlükten kayıt oluşturur.
+    @classmethod
+    def from_dict(cls, data: Mapping[str, object]) -> "ProjectRecord":
+        """Sözlük bilgisinden proje kaydı üretir."""
+
+        return cls(
+            name=str(data["name"]),
+            description=str(data.get("description", "")),
+            tech_stack=list(data.get("tech_stack", [])),
+            goals=list(data.get("goals", [])),
+            tasks=[TaskRecord.from_dict(entry) for entry in data.get("tasks", [])],
+            milestones=[
+                MilestoneRecord.from_dict(entry) for entry in data.get("milestones", [])
+            ],
+            linked_accounts=list(data.get("linked_accounts", [])),
+            automations=list(data.get("automations", [])),
+        )
+
+
+# Otomasyon kayıtlarını serileştiren veri sınıfı.
+@dataclass
+class AutomationRecord:
+    """Otomasyon tariflerini kalıcı forma taşıyan yapı."""
+
+    name: str
+    trigger: str
+    actions: List[str] = field(default_factory=list)
+    required_accounts: List[str] = field(default_factory=list)
+    description: Optional[str] = None
+
+    # AutomationRecipe nesnesinden kayıt üretir.
+    @classmethod
+    def from_recipe(cls, recipe: AutomationRecipe) -> "AutomationRecord":
+        """Otomasyon tarifini serileştirilebilir kayda çevirir."""
+
+        return cls(
+            name=recipe.name,
+            trigger=recipe.trigger,
+            actions=list(recipe.actions),
+            required_accounts=list(recipe.required_accounts),
+            description=recipe.description,
+        )
+
+    # Kayıt bilgisini otomasyon stüdyosuna uygular.
+    def apply(self, studio: AutomationStudio) -> AutomationRecipe:
+        """Kayıtlı tarifi otomasyon stüdyosuna yeniden ekler."""
+
+        try:
+            recipe = studio.create_recipe(
+                name=self.name,
+                trigger=self.trigger,
+                actions=self.actions,
+                required_accounts=self.required_accounts,
+                description=self.description,
+            )
+        except AutomationValidationError:
+            recipe = studio._get(self.name)
+            recipe.trigger = self.trigger
+            recipe.actions = list(self.actions)
+            recipe.required_accounts = list(self.required_accounts)
+            recipe.description = self.description
+        return recipe
+
+    # Sözlük formatı dönüşümü.
+    def to_dict(self) -> Dict[str, object]:
+        """Otomasyon kaydını JSON uyumlu sözlük olarak döndürür."""
+
+        return {
+            "name": self.name,
+            "trigger": self.trigger,
+            "actions": list(self.actions),
+            "required_accounts": list(self.required_accounts),
+            "description": self.description,
+        }
+
+    # Sözlükten kayıt üreten sınıf metodu.
+    @classmethod
+    def from_dict(cls, data: Mapping[str, object]) -> "AutomationRecord":
+        """Sözlük bilgisinden otomasyon kaydı oluşturur."""
+
+        return cls(
+            name=str(data["name"]),
+            trigger=str(data.get("trigger", "")),
+            actions=list(data.get("actions", [])),
+            required_accounts=list(data.get("required_accounts", [])),
+            description=data.get("description"),
+        )
+
+
+# Platformdaki tüm verileri kapsayan üst düzey şema sınıfı.
+@dataclass
+class DatabaseSchema:
+    """Hesap, proje ve otomasyon verilerini kapsayan serileştirme şeması."""
+
+    accounts: List[AccountRecord] = field(default_factory=list)
+    projects: List[ProjectRecord] = field(default_factory=list)
+    automations: List[AutomationRecord] = field(default_factory=list)
+
+    # Platformdaki güncel durumdan şema üreten yardımcı fonksiyon.
+    @classmethod
+    def from_platform(cls, platform: AppLabAgentPlatform) -> "DatabaseSchema":
+        """Verilen platform örneğindeki durumu serileştirilebilir şemaya dönüştürür."""
+
+        accounts = [AccountRecord.from_linked_account(acc) for acc in platform.accounts.list_accounts()]
+        projects = [ProjectRecord.from_project(project) for project in platform.workspace.list_projects()]
+        automations = [AutomationRecord.from_recipe(recipe) for recipe in platform.automation_studio.list_recipes()]
+        return cls(accounts=accounts, projects=projects, automations=automations)
+
+    # Şemayı yeni bir platform örneğine uygular.
+    def to_platform(self) -> AppLabAgentPlatform:
+        """Serileştirilmiş durumdan yeni bir platform örneği oluşturur."""
+
+        platform = AppLabAgentPlatform()
+        self.apply_to_platform(platform)
+        return platform
+
+    # Şemanın var olan platforma uygulanmasını sağlayan metot.
+    def apply_to_platform(self, platform: AppLabAgentPlatform) -> None:
+        """Şemadaki verileri var olan platform örneğine yükler."""
+
+        for account_record in self.accounts:
+            try:
+                platform.accounts.register(
+                    account_record.provider,
+                    account_record.name,
+                    metadata=account_record.metadata,
+                    tags=account_record.tags,
+                )
+            except Exception:
+                # Kayıt mevcutsa meta veriyi güncelliyoruz.
+                platform.accounts.update_metadata(
+                    account_record.provider,
+                    account_record.name,
+                    **account_record.metadata,
+                )
+        for project_record in self.projects:
+            project_record.apply(platform.workspace, platform.accounts)
+        for automation_record in self.automations:
+            automation_record.apply(platform.automation_studio)
+
+    # Şemayı sözlük formatına çeviren metot.
+    def to_dict(self) -> Dict[str, object]:
+        """Şema verisini JSON uyumlu sözlük olarak döndürür."""
+
+        return {
+            "accounts": [record.to_dict() for record in self.accounts],
+            "projects": [record.to_dict() for record in self.projects],
+            "automations": [record.to_dict() for record in self.automations],
+        }
+
+    # Sözlükten şema oluşturan sınıf metodu.
+    @classmethod
+    def from_dict(cls, data: Mapping[str, object]) -> "DatabaseSchema":
+        """Sözlük yapısından şema nesnesi üretir."""
+
+        return cls(
+            accounts=[AccountRecord.from_dict(entry) for entry in data.get("accounts", [])],
+            projects=[ProjectRecord.from_dict(entry) for entry in data.get("projects", [])],
+            automations=[AutomationRecord.from_dict(entry) for entry in data.get("automations", [])],
+        )

--- a/app_lab_agent/tasks.py
+++ b/app_lab_agent/tasks.py
@@ -1,0 +1,217 @@
+"""Projelerdeki görevleri ve durumlarını yönetmek için yardımcı bileşenler."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Dict, Iterable, List, Mapping, Optional
+
+
+# Görev yaşam döngüsündeki olası durumları tanımlayan enum.
+class TaskStatus(str, Enum):
+    """Görevlerin takibini kolaylaştırmak için kullanılan durumlar."""
+
+    PENDING = "pending"
+    IN_PROGRESS = "in_progress"
+    BLOCKED = "blocked"
+    DONE = "done"
+
+
+# Bir proje içindeki tekil görevleri temsil eden veri sınıfı.
+@dataclass
+class Task:
+    """Görev detaylarını ve takip bilgilerini saklar."""
+
+    identifier: str
+    title: str
+    description: str
+    status: TaskStatus = TaskStatus.PENDING
+    owner: Optional[str] = None
+    notes: List[str] = field(default_factory=list)
+
+    # Göreve not eklemek için küçük bir yardımcı fonksiyon.
+    def add_note(self, note: str) -> None:
+        """Görevle ilgili alınan yeni notu saklar."""
+
+        self.notes.append(note)
+
+
+# Görevleri gruplayarak takip eden pano sınıfı.
+class TaskBoard:
+    """Bir projeye ait görevleri takip etmek için kontrol paneli sağlar."""
+
+    def __init__(self, tasks: Optional[Iterable[Task]] = None) -> None:
+        self._tasks: Dict[str, Task] = {}
+        if tasks:
+            for task in tasks:
+                self.add_task(task)
+
+    # Yeni görev eklemeye yarayan temel metot.
+    def add_task(self, task: Task) -> None:
+        """Görevi panoya ekler, aynı kimlik mevcutsa hata verir."""
+
+        if task.identifier in self._tasks:
+            raise ValueError(f"{task.identifier!r} kimliğine sahip görev zaten mevcut.")
+        self._tasks[task.identifier] = task
+
+    # Görev durumunu beklemeden devam ediyor konumuna çeken metot.
+    def mark_in_progress(self, identifier: str, owner: Optional[str] = None) -> Task:
+        """Görevi 'in_progress' olarak işaretler ve isteğe göre sorumlu atar."""
+
+        task = self._get(identifier)
+        task.status = TaskStatus.IN_PROGRESS
+        if owner is not None:
+            task.owner = owner
+        return task
+
+    # Görevi engellendi olarak işaretleyen metot.
+    def block_task(self, identifier: str, reason: str) -> Task:
+        """Görevi 'blocked' durumuna taşır ve açıklama ekler."""
+
+        task = self._get(identifier)
+        task.status = TaskStatus.BLOCKED
+        task.add_note(f"BLOCKED: {reason}")
+        return task
+
+    # Görevi tamamlandı olarak işaretleyen metot.
+    def mark_done(self, identifier: str) -> Task:
+        """Görevi 'done' olarak işaretleyip döndürür."""
+
+        task = self._get(identifier)
+        task.status = TaskStatus.DONE
+        return task
+
+    # Görevi id ile sorgulayan yardımcı fonksiyon.
+    def get_task(self, identifier: str) -> Task:
+        """Verilen kimliğe sahip görevi panodan döndürür."""
+
+        return self._get(identifier)
+
+    # Görevleri durumlarına göre süzen metot.
+    def list_by_status(self, status: Optional[TaskStatus] = None) -> List[Task]:
+        """Belirli bir durumdaki görevleri veya tüm görevleri sıralar."""
+
+        if status is None:
+            return list(self._tasks.values())
+        return [task for task in self._tasks.values() if task.status == status]
+
+    # Görevleri sahiplerine göre listeleyen yardımcı metot.
+    def list_by_owner(self, owner: str, include_unassigned: bool = False) -> List[Task]:
+        """Belirtilen kişiye atanmış görevleri isteğe göre boş atamalarla birlikte döndürür."""
+
+        normalized = owner.strip().lower()
+        matched: List[Task] = []
+        for task in self._tasks.values():
+            if task.owner is None:
+                if include_unassigned:
+                    matched.append(task)
+                continue
+            if task.owner.strip().lower() == normalized:
+                matched.append(task)
+        return matched
+
+    # Frontend ön izlemeleri için görevleri sıralı biçimde dışa aktaran yardımcı metot.
+    def export_tasks(self) -> List[Mapping[str, object]]:
+        """Görevleri durum önceliğiyle sıralayıp JSON uyumlu sözlükler halinde döndürür."""
+
+        status_order = [
+            TaskStatus.IN_PROGRESS,
+            TaskStatus.BLOCKED,
+            TaskStatus.PENDING,
+            TaskStatus.DONE,
+        ]
+        status_priority = {status: index for index, status in enumerate(status_order)}
+        ordered_tasks = sorted(
+            enumerate(self._tasks.values()),
+            key=lambda item: (
+                status_priority.get(item[1].status, len(status_priority)),
+                item[0],
+            ),
+        )
+
+        exported: List[Mapping[str, object]] = []
+        for _, task in ordered_tasks:
+            exported.append(
+                {
+                    "identifier": task.identifier,
+                    "title": task.title,
+                    "description": task.description,
+                    "status": task.status.value,
+                    "owner": task.owner,
+                    "notes": list(task.notes),
+                }
+            )
+        return exported
+
+    # Görev sahiplerinin iş yükü dağılımını raporlayan yardımcı metot.
+    def workload_by_owner(
+        self, include_unassigned: bool = False
+    ) -> List[Mapping[str, object]]:
+        """Görevleri sorumlularına göre gruplayıp durum dağılımı ile döndürür."""
+
+        workloads: Dict[str, Dict[str, object]] = {}
+        for task in self._tasks.values():
+            owner = task.owner.strip() if task.owner else None
+            if owner is None and not include_unassigned:
+                continue
+
+            normalized = owner.lower() if owner else "__unassigned__"
+            bucket = workloads.setdefault(
+                normalized,
+                {
+                    "owner": owner,
+                    "normalized_owner": normalized,
+                    "total": 0,
+                    "status_breakdown": {status.value: 0 for status in TaskStatus},
+                    "tasks": [],
+                },
+            )
+
+            bucket["total"] += 1
+            status_label = task.status.value
+            bucket["status_breakdown"][status_label] += 1
+            bucket["tasks"].append(
+                {
+                    "identifier": task.identifier,
+                    "title": task.title,
+                    "status": status_label,
+                }
+            )
+
+        return sorted(
+            workloads.values(),
+            key=lambda item: (
+                -item["total"],
+                1 if item["normalized_owner"] == "__unassigned__" else 0,
+                item["normalized_owner"],
+            ),
+        )
+
+    # Görev panosunun ilerleme oranını hesaplayan metot.
+    def progress_report(self) -> Dict[str, object]:
+        """Durumlara göre görev sayılarını ve tamamlanma yüzdesini döndürür."""
+
+        total = len(self._tasks)
+        status_counts = {status: 0 for status in TaskStatus}
+        for task in self._tasks.values():
+            status_counts[task.status] += 1
+
+        done = status_counts[TaskStatus.DONE]
+        completion = (done / total) if total else 0.0
+        return {
+            "total": total,
+            "done": done,
+            "in_progress": status_counts[TaskStatus.IN_PROGRESS],
+            "blocked": status_counts[TaskStatus.BLOCKED],
+            "pending": status_counts[TaskStatus.PENDING],
+            "completion_ratio": completion,
+        }
+
+    # İçeride kullanılan ortak görev alma fonksiyonu.
+    def _get(self, identifier: str) -> Task:
+        """Görev panosunda ilgili kimliği arar, bulunamazsa hata üretir."""
+
+        try:
+            return self._tasks[identifier]
+        except KeyError as exc:  # pragma: no cover - hata mesajını özelleştiriyoruz.
+            raise KeyError(f"{identifier!r} kimliğine sahip görev bulunamadı.") from exc

--- a/docs/frontend_integration.md
+++ b/docs/frontend_integration.md
@@ -1,0 +1,83 @@
+# Frontend Entegrasyon Rehberi
+
+AppLabAgent paketi doğrudan bir kullanıcı arayüzü sunmaz; ancak mevcut Python API'lerini
+kullanarak frontend projelerine veri sağlayabilirsiniz. Bu rehber, görev ve proje
+bilgilerini web tabanlı arayüzlerde göstermek için temel entegrasyon adımlarını
+anlatmaktadır.
+
+## 1. Platform Katmanını Servisleştirme
+
+İlk adım, `AppLabAgentPlatform` örneğini HTTP üzerinden servis etmek için hafif bir web
+çerçevesi (ör. FastAPI veya Flask) kullanmaktır. Aşağıdaki örnek, FastAPI ile görev
+listesini yayınlayan basit bir uç nokta tanımlar:
+
+```python
+"""FastAPI ile AppLabAgentPlatform verilerini servis etme örneği."""
+from fastapi import FastAPI
+from app_lab_agent import AppLabAgentPlatform
+
+app = FastAPI(title="AppLabAgent API")
+platform = AppLabAgentPlatform()
+
+
+@app.get("/projects/{project_name}/tasks")
+def list_project_tasks(project_name: str):
+    """İstenen projenin görevlerini frontend'e JSON olarak aktar."""
+
+    workspace = platform.project_workspace(project_name)
+    return workspace.board.export_tasks()
+```
+
+Bu servis, frontend uygulamanızın ihtiyaç duyduğu veri formatını üretir. Daha ileri
+senaryolarda, hesap bağlama veya otomasyon tariflerini tetikleme için ek uç noktalar
+oluşturabilirsiniz.
+
+## 2. Frontend İsteklerini Planlama
+
+- **Durum yönetimi:** Frontend tarafında, görev panoları ve kilometre taşları gibi
+  veri setlerini önbelleğe almak için bir durum yönetim kütüphanesi (Redux, Zustand vb.)
+  kullanın.
+- **Gerçek zamanlı güncellemeler:** Görev durum geçişlerini (başlatma, tamamlama,
+  bloklama) websocket veya SSE ile dinleyerek kullanıcılara anlık geri bildirim verin.
+- **Filtreleme ve sıralama:** `list_tasks_for_owner`, `overdue_project_milestones`
+  gibi platform yardımcılarını parametreleriyle çağırarak frontend filtrelerini basit
+  tutun.
+
+## 3. UI Bileşenlerini Haritalama
+
+Frontend komponentlerinizi AppLabAgent veri modeline göre yapılandırın:
+
+- **Görev kartları:** `Task` nesnesinin `identifier`, `title`, `status`, `owner`
+  alanlarını kart bileşenlerinde gösterin.
+- **İlerleme özetleri:** `owner_workload_report` çıktısını kullanarak sorumlu bazlı
+  istatistik grafiklerini (progress bar, donut chart vb.) çizdirin.
+- **Kilometre taşı listeleri:** `ProjectWorkspace.upcoming_milestones` ve
+  `ProjectWorkspace.overdue_milestones` sonuçlarını tablo veya takvim bileşenlerinde
+  sergileyin.
+
+## 4. Menü Yapısını Doğrulama
+
+- `AppLabAgentPlatform.navigation_menu()` metodunu çağırarak tüm menü bölümlerini tek
+  seferde elde edin.
+- Dönen yapının `missing_sections` ve `empty_sections` alanlarını kontrol ederek backend
+  veritabanında eksik kayıt olup olmadığını hızlıca anlayın.
+- Menü maddeleri, `route` ve `badge` alanlarıyla frontend yönlendirmelerini kolaylaştırır;
+  bu sayede durum rozetleri veya sayım etiketlerini doğrudan UI bileşenlerine bağlayın.
+
+## 5. Stil ve Yerelleştirme
+
+- Uygulama temalarınızı AppLabAgent verilerinin yerelleştirilmiş metinleriyle uyumlu
+  hale getirmek için i18n katmanları kullanın.
+- Durum bazlı renk kodlarını ("in_progress", "blocked", "completed") tasarım
+  sisteminizde belirleyip tüm kartlarda tutarlı biçimde uygulayın.
+
+## 6. Geliştirme Akışı Önerileri
+
+1. Backend servisinizde örnek veri seti oluşturun ve snapshot'ını `DatabaseSchema`
+   ile kaydedin.
+2. Frontend geliştirme ortamında bu snapshot'ı mock API cevabı olarak kullanın.
+3. UI bileşenlerini gerçek API'ya bağlamadan önce snapshot verisiyle test ederek
+   tasarım geri bildirim döngüsünü hızlandırın.
+
+Bu adımları izleyerek AppLabAgent'ın sağladığı proje ve görev yönetimi yeteneklerini
+frontend uygulamalarınıza hızlı biçimde entegre edebilirsiniz.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Pytest çalışırken paket kök dizinini Python yoluna ekler."""
+
+import sys
+from pathlib import Path
+
+# Proje kök dizinini sys.path içerisine alarak modül içe aktarmayı kolaylaştırıyoruz.
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -1,0 +1,51 @@
+"""AccountRegistry bileşenine ait davranışları doğrulayan testler."""
+
+from app_lab_agent.accounts import AccountRegistry, AccountRegistryError
+
+
+# Hesap kayıt akışını doğrulayan test.
+def test_register_and_list_accounts():
+    registry = AccountRegistry()
+    registry.register("github", "studio", {"plan": "team"}, tags=["scm"])
+    registry.register("slack", "notifications", {"workspace": "applab"})
+
+    accounts = registry.list_accounts()
+    assert [(account.provider, account.name) for account in accounts] == [
+        ("github", "studio"),
+        ("slack", "notifications"),
+    ]
+    assert accounts[1].metadata["workspace"] == "applab"
+
+
+# Aynı isimle ikinci defa kayıt yapılmasını engelleyen hata senaryosu.
+def test_register_duplicate_account_raises():
+    registry = AccountRegistry()
+    registry.register("github", "studio")
+
+    try:
+        registry.register("GitHub", "Studio")
+    except AccountRegistryError as exc:
+        assert "zaten kayıtlı" in str(exc)
+    else:  # pragma: no cover - test başarısız olduğunda devreye girer.
+        raise AssertionError("Yinelenen hesaplar engellenmeliydi.")
+
+
+# Meta veri güncelleme davranışını doğrulayan test.
+def test_update_metadata_merges_values():
+    registry = AccountRegistry()
+    registry.register("github", "studio", {"plan": "team"})
+
+    updated = registry.update_metadata("github", "studio", region="eu")
+    assert updated.metadata == {"plan": "team", "region": "eu"}
+
+
+# Serileştirme ve tersine çevirme akışını doğrulayan test.
+def test_registry_serialization_roundtrip():
+    registry = AccountRegistry()
+    registry.register("github", "studio", {"plan": "team"})
+    registry.register("slack", "notifications", {"workspace": "applab"}, tags=["alerts"])
+
+    exported = registry.to_dict()
+    restored = AccountRegistry.from_dict(exported)
+    assert len(restored.list_accounts()) == 2
+    assert restored.get("slack", "notifications").tags == ("alerts",)

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -1,0 +1,65 @@
+"""Navigation menüsünün üretimi ve durum denetimlerini doğrulayan testler."""
+
+from app_lab_agent import AppLabAgentPlatform
+
+
+# Menü yapısının tüm bölümleri ile dolu biçimde üretildiğini doğrulayan test.
+def test_navigation_menu_includes_platform_entities():
+    platform = AppLabAgentPlatform()
+    platform.link_account("github", "studio", metadata={"plan": "team"}, tags=["ci"])
+    project = platform.create_project(
+        name="Portal",
+        description="Geliştirici portalı",
+        tech_stack=["python"],
+        tasks=[
+            {
+                "identifier": "draft-docs",
+                "title": "Doküman taslağını hazırla",
+                "description": "Başlangıç rehberini yaz",
+            }
+        ],
+    )
+    platform.create_automation(
+        name="Deploy pipeline",
+        trigger="pull_request",
+        actions=["lint", "deploy"],
+        required_accounts=["github:studio"],
+        description="PR açıldığında devreye giren otomasyon",
+    )
+    platform.start_project_task(project.name, "draft-docs", owner="Ayşe")
+    platform.complete_project_task(project.name, "draft-docs")
+
+    menu = platform.navigation_menu()
+
+    assert menu["missing_sections"] == []
+    sections = {section["identifier"]: section for section in menu["sections"]}
+    assert set(sections) == {"overview", "accounts", "projects", "automations"}
+
+    account_entry = sections["accounts"]["items"][0]
+    assert account_entry["route"] == "/accounts/github/studio"
+    assert account_entry["badge"] == "1 etiket"
+
+    project_entry = sections["projects"]["items"][0]
+    assert project_entry["badge"] == "1/1"
+    assert project_entry["route"] == "/projects/portal"
+
+    automation_entry = sections["automations"]["items"][0]
+    assert automation_entry["badge"] == "2 adım"
+    assert automation_entry["route"] == "/automations/deploy-pipeline"
+
+    overview_item = sections["overview"]["items"][0]
+    assert overview_item["badge"] == "1"
+
+
+# Menüde veri olmadığında boş bölümlerin işaretlendiğini doğrulayan test.
+def test_navigation_menu_flags_empty_sections_without_records():
+    platform = AppLabAgentPlatform()
+
+    menu = platform.navigation_menu()
+
+    assert menu["missing_sections"] == []
+    assert set(menu["empty_sections"]) == {"accounts", "projects", "automations"}
+
+    sections = {section["identifier"]: section for section in menu["sections"]}
+    assert sections["overview"]["items"][0]["badge"] == "0"
+    assert sections["accounts"]["items"] == []

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -1,0 +1,352 @@
+"""AppLabAgentPlatform orkestrasyon davranışlarını sınayan testler."""
+
+import pytest
+
+from app_lab_agent import (
+    AppLabAgentError,
+    AppLabAgentPlatform,
+    AutomationValidationError,
+    MilestoneStatus,
+    TaskStatus,
+    ProjectWorkspaceError,
+)
+
+
+# Platformun uçtan uca proje ve otomasyon senaryosunu yönettiğini test eder.
+def test_platform_end_to_end_flow():
+    platform = AppLabAgentPlatform()
+    platform.link_account("github", "studio", {"plan": "team"})
+    platform.link_account("slack", "alerts")
+
+    project = platform.create_project(
+        name="Automation",
+        description="Otomasyon tasarlama",
+        tech_stack=["python", "n8n"],
+        goals=["PoC"],
+        tasks=[
+            {"identifier": "research", "title": "Araştırma", "description": "Rakip analizi"},
+        ],
+    )
+    platform.workspace.link_account_to_project("Automation", "github", "studio")
+
+    recipe = platform.create_automation(
+        name="Deploy bot",
+        trigger="pull_request",
+        actions=["lint", "deploy"],
+        required_accounts=["github:studio", "slack:alerts"],
+        description="PR açıldığında otomatik kontrol",
+    )
+
+    overview = platform.portfolio_overview()
+    assert overview["projects"][0]["name"] == project.name
+    assert len(overview["accounts"]) == 2
+    assert overview["automations"][0]["name"] == recipe.name
+
+    assignment = platform.assign_automation_to_project("Automation", "Deploy bot")
+    assert assignment["project"]["name"] == "Automation"
+    progress_tasks = assignment["project"]["progress"]["tasks"]
+    assert any(task["title"].startswith("Otomasyon devreye alma") for task in progress_tasks)
+
+
+# Gerekli hesaplar yoksa otomasyon ataması sırasında hata fırlatıldığını test eder.
+def test_assign_automation_raises_when_accounts_missing():
+    platform = AppLabAgentPlatform()
+    platform.create_project("Site", "Kurumsal site", ["astro"], tasks=[])
+    platform.create_automation("Notify", "webhook", ["send"], required_accounts=["slack:alerts"])
+
+    try:
+        platform.assign_automation_to_project("Site", "Notify")
+    except AutomationValidationError as exc:
+        assert "Eksik hesaplar" in str(exc)
+    else:  # pragma: no cover - hata fırlatılmazsa test başarısız.
+        raise AssertionError("Eksik hesaplar için hata bekleniyordu.")
+
+
+# Projenin ihtiyaç duyduğu hesaplar sağlanmadığında özel hata oluştuğunu test eder.
+def test_ensure_project_has_accounts_detects_missing():
+    platform = AppLabAgentPlatform()
+    platform.create_project("Mobil", "Mobil uygulama", ["flutter"], tasks=[])
+
+    try:
+        platform.ensure_project_has_accounts("Mobil", ["github"])
+    except AppLabAgentError as exc:
+        assert "eksik sağlayıcılar" in str(exc)
+    else:  # pragma: no cover - hata bekleniyordu.
+        raise AssertionError("Gerekli sağlayıcı eksik olduğunda hata fırlatılmalıydı.")
+
+
+# Platform API'si üzerinden görev durumlarını yönetebildiğimizi doğrular.
+def test_platform_updates_project_tasks():
+    platform = AppLabAgentPlatform()
+    platform.create_project(
+        name="Analytics",
+        description="Implement dashboards",
+        tech_stack=["python"],
+        tasks=[
+            {
+                "identifier": "draft-dashboard",
+                "title": "Draft dashboard",
+                "description": "Sketch charts",
+                "owner": "Ece",
+            }
+        ],
+    )
+
+    started = platform.start_project_task("Analytics", "draft-dashboard", owner="Kerem")
+    assert started.status.value == "in_progress"
+    assert started.owner == "Kerem"
+
+    platform.block_project_task("Analytics", "draft-dashboard", "Needs data source")
+    project = platform.workspace._get_project("Analytics")
+    task = project.task_board.get_task("draft-dashboard")
+    assert task.status.value == "blocked"
+    assert task.notes[-1] == "BLOCKED: Needs data source"
+
+    completed = platform.complete_project_task("Analytics", "draft-dashboard")
+    assert completed.status.value == "done"
+
+
+# Kilometre taşı API'sinin platform üzerinden çalıştığını doğrular.
+def test_platform_manages_milestones():
+    platform = AppLabAgentPlatform()
+    platform.create_project("Docs", "Belgeler", ["mkdocs"], tasks=[])
+
+    milestone = platform.add_project_milestone(
+        "Docs",
+        title="İlk yayın",
+        description="Beta dokümantasyonu yayınla",
+        due_date="2024-10-20",
+    )
+    assert milestone.status == MilestoneStatus.PENDING
+
+    platform.complete_project_milestone("Docs", "İlk yayın")
+    upcoming = platform.upcoming_project_milestones(include_completed=True)
+    assert upcoming[0]["status"] == MilestoneStatus.COMPLETED.value
+    assert upcoming[0]["project"] == "Docs"
+
+
+# Platformun proje çalışma alanını ön izleme için döndürebildiğini doğrular.
+def test_platform_project_workspace_exposes_board_export():
+    platform = AppLabAgentPlatform()
+    platform.create_project(
+        name="Preview",
+        description="Ön izleme",
+        tech_stack=["python"],
+        tasks=[
+            {
+                "identifier": "outline",
+                "title": "Taslak",
+                "description": "İçeriği toparla",
+                "owner": "Can",
+            }
+        ],
+    )
+    platform.start_project_task("Preview", "outline")
+
+    workspace = platform.project_workspace("Preview")
+    exported = workspace.board.export_tasks()
+    assert exported[0]["identifier"] == "outline"
+    assert exported[0]["status"] == TaskStatus.IN_PROGRESS.value
+
+
+# Platform API'sinin geciken kilometre taşlarını raporladığını doğrular.
+def test_platform_reports_overdue_milestones():
+    platform = AppLabAgentPlatform()
+    platform.create_project("Risk", "Risk izleme", ["python"], tasks=[])
+
+    platform.add_project_milestone(
+        "Risk",
+        title="Uyarı altyapısı",
+        description="Uyarı kurallarını oluştur",
+        due_date="2024-01-04",
+    )
+    platform.add_project_milestone(
+        "Risk",
+        title="Sürüm planı",
+        description="Yeni sprint planını hazırla",
+        due_date="2024-01-09",
+    )
+    platform.add_project_milestone(
+        "Risk",
+        title="Rapor paylaşımı",
+        description="Paydaşlara sunum yap",
+        due_date="2024-01-02",
+    )
+    platform.complete_project_milestone("Risk", "Rapor paylaşımı")
+
+    overdue = platform.overdue_project_milestones(reference_date="2024-01-08")
+    assert [entry["milestone"] for entry in overdue] == ["Uyarı altyapısı"]
+
+    overdue_with_completed = platform.overdue_project_milestones(
+        reference_date="2024-01-08", include_completed=True
+    )
+    assert [entry["milestone"] for entry in overdue_with_completed] == [
+        "Rapor paylaşımı",
+        "Uyarı altyapısı",
+    ]
+
+
+# Platformun sorumlu bazlı görev raporunu sunduğunu doğrular.
+def test_platform_lists_tasks_for_owner():
+    platform = AppLabAgentPlatform()
+    platform.create_project(
+        name="Docs",
+        description="Belgeleri güncelle",
+        tech_stack=["mkdocs"],
+        tasks=[
+            {
+                "identifier": "outline",
+                "title": "İçerik taslağı",
+                "description": "Başlıkları planla",
+                "owner": "Leyla",
+            },
+            {
+                "identifier": "review",
+                "title": "Takım incelemesi",
+                "description": "Geri bildirim topla",
+                "owner": "leyla",
+            },
+            {
+                "identifier": "publish",
+                "title": "Yayınla",
+                "description": "Siteyi dağıt",
+            },
+        ],
+    )
+    platform.create_project(
+        name="Infra",
+        description="Altyapı taşıması",
+        tech_stack=["terraform"],
+        tasks=[
+            {
+                "identifier": "migrate-db",
+                "title": "Veritabanını taşı",
+                "description": "Yeni kümeye geç",
+                "owner": "Arda",
+            }
+        ],
+    )
+
+    platform.block_project_task("Docs", "review", "Eksik onay")
+    platform.start_project_task("Docs", "outline")
+
+    report = platform.list_tasks_for_owner("leyla")
+    assert [entry["identifier"] for entry in report] == ["review", "outline"]
+    assert report[0]["status"] == "blocked"
+    assert report[1]["status"] == "in_progress"
+
+    report_with_unassigned = platform.list_tasks_for_owner(
+        "Leyla", include_unassigned=True
+    )
+    assert {entry["identifier"] for entry in report_with_unassigned} == {
+        "review",
+        "outline",
+        "publish",
+    }
+    assert next(
+        entry for entry in report_with_unassigned if entry["identifier"] == "publish"
+    )["owner"] is None
+
+    with pytest.raises(ProjectWorkspaceError):
+        platform.list_tasks_for_owner("")
+
+
+# Platformun sorumlu bazlı iş yükü özetini sunduğunu doğrular.
+def test_platform_owner_workload_report_combines_projects():
+    platform = AppLabAgentPlatform()
+    platform.create_project(
+        name="Docs",
+        description="Belgeleri güncelle",
+        tech_stack=["mkdocs"],
+        tasks=[
+            {
+                "identifier": "outline",
+                "title": "İçerik taslağı",
+                "description": "Başlıkları planla",
+                "owner": "Leyla",
+            },
+            {
+                "identifier": "review",
+                "title": "Takım incelemesi",
+                "description": "Geri bildirim topla",
+                "owner": "Arda",
+            },
+            {
+                "identifier": "publish",
+                "title": "Yayınla",
+                "description": "Siteyi dağıt",
+            },
+        ],
+    )
+    platform.create_project(
+        name="Infra",
+        description="Altyapı taşıması",
+        tech_stack=["terraform"],
+        tasks=[
+            {
+                "identifier": "migrate-db",
+                "title": "Veritabanını taşı",
+                "description": "Yeni kümeye geç",
+                "owner": "Leyla",
+            }
+        ],
+    )
+
+    platform.start_project_task("Docs", "outline")
+    platform.block_project_task("Docs", "review", "Eksik onay")
+    platform.complete_project_task("Infra", "migrate-db")
+
+    summary = platform.owner_workload_report(include_unassigned=True)
+
+    assert [entry["normalized_owner"] for entry in summary] == [
+        "leyla",
+        "arda",
+        "__unassigned__",
+    ]
+
+    leyla_entry = summary[0]
+    assert leyla_entry["total"] == 2
+    assert leyla_entry["status_breakdown"][TaskStatus.DONE.value] == 1
+    assert {
+        project_info["project"] for project_info in leyla_entry["projects"]
+    } == {"Docs", "Infra"}
+
+    unassigned_entry = summary[-1]
+    assert unassigned_entry["owner"] is None
+    assert unassigned_entry["status_breakdown"][TaskStatus.PENDING.value] == 1
+
+
+# Entegrasyon denetiminin eksik hesap ve otomasyon boşluklarını raporladığını test eder.
+def test_platform_integration_audit_flags_missing_links():
+    platform = AppLabAgentPlatform()
+    platform.link_account("aws", "prod", {"region": "eu-west-1"}, tags=["terraform", "cloud"])
+    platform.link_account("snowflake", "warehouse", tags=["dbt"])
+
+    platform.create_project(
+        name="Data Mesh",
+        description="Analitik veri platformu",
+        tech_stack=["AWS", "dbt", "Airflow"],
+        tasks=[],
+    )
+    platform.workspace.link_account_to_project("Data Mesh", "aws", "prod")
+
+    platform.create_automation(
+        name="Model Sync",
+        trigger="schedule",
+        actions=["dbt run"],
+        required_accounts=["snowflake:warehouse"],
+    )
+    platform.assign_automation_to_project("Data Mesh", "Model Sync")
+
+    project = platform.workspace._get_project("Data Mesh")
+    project.automations.append("Legacy Flow")
+
+    audit = platform.integration_audit()
+    assert len(audit) == 1
+    entry = audit[0]
+    assert entry["project"] == "Data Mesh"
+    assert entry["status"] == "needs_attention"
+    assert "Airflow" in entry["missing_account_integrations"]
+    assert "AWS" in entry["tech_coverage"]
+    assert entry["tech_coverage"]["dbt"][0]["provider"] == "snowflake"
+    assert any(gap["automation"] == "Legacy Flow" for gap in entry["automation_gaps"])

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -1,0 +1,307 @@
+"""ProjectWorkspace bileşeninin temel senaryolarını doğrular."""
+
+import pytest
+
+from app_lab_agent.accounts import AccountRegistry
+from app_lab_agent.projects import MilestoneStatus, ProjectWorkspace, ProjectWorkspaceError
+from app_lab_agent.tasks import TaskStatus
+
+
+# Proje oluşturma, görev ekleme ve hesap bağlama akışını test eder.
+def test_create_project_and_link_account():
+    accounts = AccountRegistry()
+    accounts.register("github", "studio", {"plan": "team"})
+    workspace = ProjectWorkspace(accounts)
+
+    project = workspace.create_project(
+        name="App Platform",
+        description="Müşteriler için otomasyon platformu",
+        tech_stack=["python", "fastapi"],
+        goals=["MVP teslimi"],
+    )
+    workspace.add_task_to_project(
+        "App Platform",
+        identifier="design",
+        title="Bilgi mimarisi",
+        description="Bilgi mimarisi çalışmasını tamamla",
+    )
+    linked = workspace.link_account_to_project("App Platform", "github", "studio")
+
+    assert project.summary()["progress"]["total"] == 1
+    assert linked.name == "studio"
+    assert workspace.status_overview()["App Platform"]["pending"] == 1
+
+
+# Belirli sağlayıcısı olmayan projeleri döndürme davranışını test eder.
+def test_find_projects_needing_account_filters_correctly():
+    accounts = AccountRegistry()
+    accounts.register("github", "studio")
+    workspace = ProjectWorkspace(accounts)
+    workspace.create_project(
+        name="Automation",
+        description="n8n entegrasyonu",
+        tech_stack=["n8n", "supabase"],
+    )
+    workspace.create_project(
+        name="Website",
+        description="Kurumsal site",
+        tech_stack=["astro"],
+    )
+    workspace.link_account_to_project("Website", "github", "studio")
+
+    missing = workspace.find_projects_needing_account("github")
+    assert [project.name for project in missing] == ["Automation"]
+
+
+# Görev durumlarını çalışma alanı üzerinden ilerletebildiğimizi doğrular.
+def test_workspace_can_advance_task_statuses():
+    accounts = AccountRegistry()
+    workspace = ProjectWorkspace(accounts)
+    workspace.create_project(
+        name="Ops",
+        description="Internal tooling",
+        tech_stack=["python"],
+    )
+    workspace.add_task_to_project(
+        "Ops", "draft-spec", "Draft spec", "Outline requirements", owner="Leyla"
+    )
+
+    in_progress = workspace.start_task("Ops", "draft-spec", owner="Arda")
+    assert in_progress.status.value == "in_progress"
+    assert in_progress.owner == "Arda"
+
+    blocked = workspace.block_task("Ops", "draft-spec", reason="Waiting for approval")
+    assert blocked.status.value == "blocked"
+    assert blocked.notes[-1] == "BLOCKED: Waiting for approval"
+
+    done = workspace.complete_task("Ops", "draft-spec")
+    assert done.status.value == "done"
+
+
+# Kilometre taşlarını ekleme ve tamamlama akışını doğrular.
+def test_workspace_manages_milestones():
+    workspace = ProjectWorkspace()
+    workspace.create_project(
+        name="Mobile",
+        description="Mobil uygulama",
+        tech_stack=["flutter"],
+    )
+
+    milestone = workspace.add_milestone(
+        "Mobile",
+        title="Beta yayını",
+        description="Kapalı beta sürümünü yayınla",
+        due_date="2024-12-01",
+    )
+    assert milestone.status == MilestoneStatus.PENDING
+
+    completed = workspace.complete_milestone("Mobile", "Beta yayını")
+    assert completed.status == MilestoneStatus.COMPLETED
+
+    upcoming = workspace.upcoming_milestones(include_completed=True)
+    assert upcoming[0]["milestone"] == "Beta yayını"
+    assert upcoming[0]["status"] == MilestoneStatus.COMPLETED.value
+
+
+# Geciken kilometre taşlarını raporlayan yardımcı metodu test eder.
+def test_workspace_reports_overdue_milestones():
+    workspace = ProjectWorkspace()
+    workspace.create_project(
+        name="Growth",
+        description="Kullanıcı kazanımı",
+        tech_stack=["python"],
+    )
+
+    workspace.add_milestone(
+        "Growth",
+        title="Aktivasyon analizi",
+        description="İlk aktivasyon metriklerini çıkar",
+        due_date="2024-01-05",
+    )
+    workspace.add_milestone(
+        "Growth",
+        title="Deney kurulumu",
+        description="A/B testi kur",
+        due_date="2024-01-10",
+    )
+    late = workspace.add_milestone(
+        "Growth",
+        title="Rapor sunumu",
+        description="Sonuçları paylaş",
+        due_date="2024-01-03",
+    )
+    late.complete()
+
+    invalid = workspace.add_milestone(
+        "Growth",
+        title="API entegrasyonu",
+        description="Partner API'sini bağla",
+        due_date="2024-01-08",
+    )
+    invalid.due_date = "invalid-date"
+
+    overdue = workspace.overdue_milestones(reference_date="2024-01-09")
+    assert [entry["milestone"] for entry in overdue] == ["Aktivasyon analizi"]
+
+    overdue_with_completed = workspace.overdue_milestones(
+        reference_date="2024-01-09", include_completed=True
+    )
+    assert [entry["milestone"] for entry in overdue_with_completed] == [
+        "Rapor sunumu",
+        "Aktivasyon analizi",
+    ]
+
+    with pytest.raises(ProjectWorkspaceError):
+        workspace.overdue_milestones(reference_date="not-a-date")
+
+
+# Görevleri sahip bazında topluca raporlayan yardımcı metodu doğrular.
+def test_workspace_tasks_for_owner_reports_with_sorting_and_filters():
+    workspace = ProjectWorkspace()
+    workspace.create_project(
+        name="Docs",
+        description="Dokümantasyon yenileme",
+        tech_stack=["md"],
+    )
+    workspace.create_project(
+        name="Infra",
+        description="Altyapı geçişi",
+        tech_stack=["terraform"],
+    )
+
+    workspace.add_task_to_project(
+        "Docs",
+        identifier="outline",
+        title="Yeni yapı taslağı",
+        description="Başlıkları düzenle",
+        owner="Leyla",
+    )
+    workspace.add_task_to_project(
+        "Docs",
+        identifier="review",
+        title="Takım değerlendirmesi",
+        description="Geri bildirim topla",
+        owner="leyla",
+    )
+    workspace.add_task_to_project(
+        "Infra",
+        identifier="migrate-db",
+        title="Veritabanını taşı",
+        description="Yeni kümeye geçiş",
+        owner="Arda",
+    )
+    workspace.add_task_to_project(
+        "Infra",
+        identifier="network",
+        title="Ağ kuralı incele",
+        description="Kuralları optimize et",
+    )
+
+    workspace.block_task("Docs", "review", "Bekleyen onay")
+    workspace.start_task("Docs", "outline", owner="Leyla")
+
+    report = workspace.tasks_for_owner("LEyla")
+    assert [entry["identifier"] for entry in report] == ["review", "outline"]
+    assert report[0]["status"] == "blocked"
+    assert report[1]["status"] == "in_progress"
+
+    report_with_unassigned = workspace.tasks_for_owner(
+        "Leyla", include_unassigned=True
+    )
+    assert {entry["identifier"] for entry in report_with_unassigned} == {
+        "review",
+        "outline",
+        "network",
+    }
+    assert next(
+        entry for entry in report_with_unassigned if entry["identifier"] == "network"
+    )["owner"] is None
+
+    with pytest.raises(ProjectWorkspaceError):
+        workspace.tasks_for_owner("   ")
+
+
+# İş yükü raporunun projeler arası birleştirilmesini test eder.
+def test_workspace_owner_workload_groups_projects():
+    workspace = ProjectWorkspace()
+    workspace.create_project(
+        name="Docs",
+        description="Dokümantasyon yenileme",
+        tech_stack=["md"],
+    )
+    workspace.create_project(
+        name="Infra",
+        description="Altyapı geçişi",
+        tech_stack=["terraform"],
+    )
+
+    workspace.add_task_to_project(
+        "Docs",
+        identifier="outline",
+        title="Yeni yapı taslağı",
+        description="Başlıkları düzenle",
+        owner="Leyla",
+    )
+    workspace.add_task_to_project(
+        "Docs",
+        identifier="review",
+        title="Takım değerlendirmesi",
+        description="Geri bildirim topla",
+        owner="Arda",
+    )
+    workspace.add_task_to_project(
+        "Infra",
+        identifier="migrate-db",
+        title="Veritabanını taşı",
+        description="Yeni kümeye geçiş",
+        owner="Leyla",
+    )
+    workspace.add_task_to_project(
+        "Infra",
+        identifier="network",
+        title="Ağ kuralı incele",
+        description="Kuralları optimize et",
+    )
+
+    workspace.start_task("Docs", "outline")
+    workspace.block_task("Docs", "review", "Bekleyen onay")
+    workspace.complete_task("Infra", "migrate-db")
+
+    summary = workspace.owner_workload(include_unassigned=True)
+
+    assert [entry["normalized_owner"] for entry in summary] == [
+        "leyla",
+        "arda",
+        "__unassigned__",
+    ]
+
+    leyla_entry = summary[0]
+    assert leyla_entry["total"] == 2
+    assert leyla_entry["status_breakdown"][TaskStatus.DONE.value] == 1
+    assert {
+        project_info["project"] for project_info in leyla_entry["projects"]
+    } == {"Docs", "Infra"}
+
+    unassigned_entry = summary[-1]
+    assert unassigned_entry["owner"] is None
+    assert unassigned_entry["status_breakdown"][TaskStatus.PENDING.value] == 1
+
+
+# Çalışma alanından proje blueprint'ini alıp pano ön izlemesini doğrulayan test.
+def test_project_workspace_returns_blueprint_with_board_export():
+    workspace = ProjectWorkspace()
+    workspace.create_project(
+        name="Preview", description="Ön izleme", tech_stack=["python"]
+    )
+    workspace.add_task_to_project(
+        "Preview", "draft", "Taslak", "İçeriği hazırla", owner="Duru"
+    )
+    workspace.start_task("Preview", "draft")
+
+    project = workspace.project_workspace("Preview")
+    assert project.board is project.task_board
+
+    exported = project.board.export_tasks()
+    assert exported[0]["identifier"] == "draft"
+    assert exported[0]["owner"] == "Duru"
+    assert exported[0]["status"] == TaskStatus.IN_PROGRESS.value

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,96 @@
+"""DatabaseSchema yardımları için senaryoları doğrulayan testler."""
+
+from app_lab_agent import AppLabAgentPlatform, MilestoneStatus, TaskStatus
+from app_lab_agent.storage import DatabaseSchema
+
+
+def build_sample_platform() -> AppLabAgentPlatform:
+    """Test senaryolarında kullanılan örnek platformu hazırlar."""
+
+    platform = AppLabAgentPlatform()
+    platform.link_account("github", "studio", {"plan": "team"}, tags=["source"])
+    platform.link_account("slack", "alerts", {"channel": "#alerts"})
+    project = platform.create_project(
+        name="Deploy bot",
+        description="Otomasyon platformu için CI/CD botu",
+        tech_stack=["python", "n8n"],
+        goals=["MVP", "Canary release"],
+        tasks=[
+            {
+                "identifier": "plan",
+                "title": "Planlama",
+                "description": "İş gereksinimlerini topla",
+                "owner": "ayse",
+            },
+            {
+                "identifier": "build",
+                "title": "CI pipeline",
+                "description": "Test ve build adımlarını oluştur",
+                "owner": "veli",
+            },
+        ],
+    )
+    platform.add_project_milestone(
+        "Deploy bot",
+        title="Canary yayını",
+        description="İlk canary dağıtımını yap",
+        due_date="2024-11-30",
+    )
+    platform.complete_project_milestone("Deploy bot", "Canary yayını")
+    project.task_board.mark_in_progress("plan", owner="ayse")
+    project.task_board.mark_done("plan")
+    project.task_board.block_task("build", "Onay bekleniyor")
+    project.task_board.get_task("build").notes.append("Test notu")
+    platform.workspace.link_account_to_project("Deploy bot", "github", "studio")
+    platform.create_automation(
+        name="Deploy",
+        trigger="pull_request",
+        actions=["lint", "deploy"],
+        required_accounts=["github:studio", "slack:alerts"],
+        description="PR açılınca otomatik dağıtım",
+    )
+    platform.assign_automation_to_project("Deploy bot", "Deploy")
+    return platform
+
+
+def test_schema_roundtrip_preserves_data():
+    """Platformdan alınan şema sözlüğe ve tekrar platforma geri dönerken veri kaybı olmaz."""
+
+    platform = build_sample_platform()
+    schema = DatabaseSchema.from_platform(platform)
+
+    serialised = schema.to_dict()
+    restored_schema = DatabaseSchema.from_dict(serialised)
+    restored_platform = restored_schema.to_platform()
+
+    restored_accounts = restored_platform.accounts.list_accounts()
+    assert {(acc.provider, acc.name) for acc in restored_accounts} == {
+        ("github", "studio"),
+        ("slack", "alerts"),
+    }
+
+    restored_project = restored_platform.workspace.list_projects()[0]
+    assert restored_project.summary()["progress"]["done"] == 1
+    build_task = restored_project.task_board.get_task("build")
+    assert build_task.status is TaskStatus.BLOCKED
+    assert "Test notu" in build_task.notes
+    milestone = restored_project.get_milestone("Canary yayını")
+    assert milestone.status is MilestoneStatus.COMPLETED
+
+    restored_recipe = restored_platform.automation_studio.list_recipes()[0]
+    assert restored_recipe.name == "Deploy"
+    assert set(restored_recipe.required_accounts) == {"github:studio", "slack:alerts"}
+
+
+def test_schema_apply_updates_existing_platform():
+    """Şema, mevcut platforma uygulandığında meta verileri güncelleyebilir."""
+
+    platform = AppLabAgentPlatform()
+    platform.link_account("github", "studio", {"plan": "free"})
+
+    baseline_schema = DatabaseSchema.from_platform(platform)
+    baseline_schema.accounts[0].metadata["plan"] = "team"
+    baseline_schema.apply_to_platform(platform)
+
+    updated_account = platform.accounts.get("github", "studio")
+    assert updated_account.metadata["plan"] == "team"

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,136 @@
+"""TaskBoard ve Task bileşenlerinin davranışlarını sınayan testler."""
+
+from app_lab_agent.tasks import Task, TaskBoard, TaskStatus
+
+
+# Görev panosunun görev ekleme ve durum güncelleme özelliklerini test eder.
+def test_task_board_lifecycle():
+    board = TaskBoard()
+    task = Task(identifier="plan", title="Plan oluştur", description="Proje için plan çıkar")
+    board.add_task(task)
+
+    board.mark_in_progress("plan", owner="melis")
+    assert board.get_task("plan").owner == "melis"
+    board.block_task("plan", "müşteri onayı bekleniyor")
+    assert board.get_task("plan").status is TaskStatus.BLOCKED
+    board.mark_done("plan")
+    assert board.get_task("plan").status is TaskStatus.DONE
+
+
+# İlerleme raporunun doğru şekilde hesaplandığını kontrol eden test.
+def test_progress_report_counts_statuses():
+    board = TaskBoard()
+    board.add_task(Task(identifier="1", title="Görev 1", description=""))
+    board.add_task(Task(identifier="2", title="Görev 2", description=""))
+    board.add_task(Task(identifier="3", title="Görev 3", description=""))
+
+    board.mark_in_progress("2")
+    board.block_task("3", "entegrasyon bekleniyor")
+    board.mark_done("1")
+
+    report = board.progress_report()
+    assert report == {
+        "total": 3,
+        "done": 1,
+        "in_progress": 1,
+        "blocked": 1,
+        "pending": 0,
+        "completion_ratio": 1 / 3,
+    }
+
+
+# İş yükü raporunun sorumlu bazında gruplanmasını doğrulayan test.
+def test_workload_by_owner_includes_status_breakdown():
+    board = TaskBoard()
+    board.add_task(
+        Task(
+            identifier="plan",
+            title="Planı hazırla",
+            description="Plan taslağı çıkar",
+            owner="Leyla",
+        )
+    )
+    board.add_task(
+        Task(
+            identifier="implement",
+            title="Uygulamayı geliştir",
+            description="Çekirdek modülü yaz",
+            owner="Leyla",
+        )
+    )
+    board.add_task(
+        Task(
+            identifier="qa",
+            title="Testleri çalıştır",
+            description="Senaryoları doğrula",
+            owner="Arda",
+        )
+    )
+    board.add_task(
+        Task(
+            identifier="docs",
+            title="Doküman yaz",
+            description="Kullanım kılavuzu hazırla",
+        )
+    )
+
+    board.mark_done("plan")
+    board.mark_in_progress("implement")
+    board.block_task("qa", "Test ortamı hazır değil")
+
+    summary = board.workload_by_owner(include_unassigned=True)
+
+    assert [entry["normalized_owner"] for entry in summary] == [
+        "leyla",
+        "arda",
+        "__unassigned__",
+    ]
+
+    leyla_summary = summary[0]
+    assert leyla_summary["total"] == 2
+    assert leyla_summary["status_breakdown"] == {
+        TaskStatus.PENDING.value: 0,
+        TaskStatus.IN_PROGRESS.value: 1,
+        TaskStatus.BLOCKED.value: 0,
+        TaskStatus.DONE.value: 1,
+    }
+    assert {task["identifier"] for task in leyla_summary["tasks"]} == {
+        "plan",
+        "implement",
+    }
+
+    unassigned_summary = summary[-1]
+    assert unassigned_summary["owner"] is None
+    assert unassigned_summary["status_breakdown"][TaskStatus.PENDING.value] == 1
+
+
+# Görev panosunun ön izleme çıktısının sıralama ve veri alanlarını doğrulayan test.
+def test_export_tasks_orders_by_status_and_keeps_notes():
+    board = TaskBoard()
+    pending = Task(identifier="pending", title="Bekleyen", description="", owner=None)
+    board.add_task(pending)
+    in_progress = Task(
+        identifier="progress",
+        title="Devam eden",
+        description="",
+        owner="Zeynep",
+    )
+    board.add_task(in_progress)
+    blocked = Task(identifier="blocked", title="Bloklu", description="", owner="Ali")
+    board.add_task(blocked)
+    done = Task(identifier="done", title="Tamamlandı", description="", owner="Eda")
+    board.add_task(done)
+
+    board.mark_in_progress("progress")
+    board.block_task("blocked", "onay bekleniyor")
+    board.mark_done("done")
+
+    exported = board.export_tasks()
+    assert [task["identifier"] for task in exported] == [
+        "progress",
+        "blocked",
+        "pending",
+        "done",
+    ]
+    blocked_payload = next(item for item in exported if item["identifier"] == "blocked")
+    assert blocked_payload["notes"] and "onay bekleniyor" in blocked_payload["notes"][0]


### PR DESCRIPTION
## Summary
- add a navigation helper module to model frontend menu sections and audit missing areas
- expose platform.navigation_menu to build sectioned menus with badges derived from accounts, projects, and automations
- document the menu workflow for frontend integrations and cover it with dedicated pytest scenarios

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d54504bbe88333bc7c16b8dca2fde2